### PR TITLE
Poller-drive slow commit-ack helpers (music, obsidian); wire obsidian ack

### DIFF
--- a/src/context_library/adapters/apple_music_library.py
+++ b/src/context_library/adapters/apple_music_library.py
@@ -100,6 +100,10 @@ class AppleMusicLibraryAdapter(HelperAckMixin, AppleMusicBaseMixin, BaseAdapter)
     def domain(self) -> Domain:
         return Domain.DOCUMENTS
 
+    # Poller-driven: embedding a large music library can exceed the mac's push
+    # timeout; the poller is not time-bounded, so commit-ack advances cleanly.
+    background_poll: bool = True
+
     @property
     def poll_strategy(self) -> PollStrategy:
         return PollStrategy.PULL

--- a/src/context_library/adapters/obsidian_helper.py
+++ b/src/context_library/adapters/obsidian_helper.py
@@ -80,6 +80,10 @@ class ObsidianHelperAdapter(RemoteAdapter):
             timeout=60.0,
         )
 
+    # Poller-driven: embedding a large vault can exceed the mac's push timeout;
+    # the poller is not time-bounded, so commit-ack advances cleanly.
+    background_poll: bool = True
+
     @property
     def poll_strategy(self) -> PollStrategy:
         return PollStrategy.PULL
@@ -91,7 +95,9 @@ class ObsidianHelperAdapter(RemoteAdapter):
     def fetch(self, source_ref: str, extra_body: dict | None = None) -> Iterator[NormalizedContent]:
         since = source_ref if source_ref else None
         headers = {"Authorization": f"Bearer {self._api_key}"}
-        params: dict = {}
+        # ack=true → commit-ack mode: the helper stages its push cursor until ack()
+        # confirms the page was durably committed (RemoteAdapter.ack()).
+        params: dict = {"ack": "true"}
         if since:
             params["since"] = since
 

--- a/src/context_library/adapters/remote.py
+++ b/src/context_library/adapters/remote.py
@@ -434,3 +434,25 @@ class RemoteAdapter(BaseAdapter):
             collector_name=self._collector_name,
             api_key=self._api_key,
         )
+
+    def ack(self) -> None:
+        """Confirm durable commit of the last fetched page (commit-ack).
+
+        POSTs /collectors/{_collector_name}/ack so the helper advances its staged
+        push cursor only after the pipeline persisted the page. Only adapters that
+        fetch with ``ack=true`` stage a cursor; for the rest this is a harmless
+        no-op on the helper. Best-effort: a failure (e.g. an older helper without
+        the endpoint) is logged, not raised, so it cannot fail an ingest.
+        """
+        headers = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        try:
+            resp = self._client.post(
+                f"{self._service_url}/collectors/{self._collector_name}/ack",
+                headers=headers,
+                timeout=10.0,
+            )
+            resp.raise_for_status()
+        except Exception as e:  # noqa: BLE001 - ack is best-effort
+            logger.warning("%s: commit-ack to helper failed: %s", type(self).__name__, e)

--- a/tests/adapters/test_apple_music_library.py
+++ b/tests/adapters/test_apple_music_library.py
@@ -105,6 +105,12 @@ class TestAppleMusicLibraryAdapterProperties:
         adapter = AppleMusicLibraryAdapter(api_url="http://127.0.0.1:7123", api_key="test-token")
         assert adapter.poll_strategy == PollStrategy.PULL
 
+    def test_background_poll_enabled(self):
+        """Poller-driven: a large library re-delivery (~2 items/track to embed) can
+        exceed the mac's push timeout; the poller is not time-bounded."""
+        adapter = AppleMusicLibraryAdapter(api_url="http://127.0.0.1:7123", api_key="test-token")
+        assert adapter.background_poll is True
+
     def test_normalizer_version_property(self):
         """normalizer_version property returns '1.0.0'."""
         adapter = AppleMusicLibraryAdapter(api_url="http://127.0.0.1:7123", api_key="test-token")

--- a/tests/adapters/test_obsidian_helper.py
+++ b/tests/adapters/test_obsidian_helper.py
@@ -152,3 +152,31 @@ class TestObsidianHelperAdapterReset:
 
         with pytest.raises(ValidationError):
             adapter.reset()
+
+
+class TestObsidianHelperAdapterCommitAck:
+    def test_background_poll_enabled(self):
+        # Poller-driven so an embedding-heavy vault re-delivery isn't bounded by
+        # the mac's push timeout.
+        assert _make_adapter().background_poll is True
+
+    def test_ack_posts_to_obsidian_ack_endpoint(self):
+        # RemoteAdapter.ack() (inherited) commits the helper's staged cursor.
+        adapter = _make_adapter(api_url="http://helper:7123", api_key="k")
+        adapter.ack()
+        args, kwargs = adapter._client.post.call_args
+        assert args[0] == "http://helper:7123/collectors/obsidian/ack"
+        assert kwargs["headers"]["Authorization"] == "Bearer k"
+
+    def test_ack_is_best_effort(self):
+        adapter = _make_adapter()
+        adapter._client.post.side_effect = RuntimeError("helper down")
+        # Must not raise — an ack failure cannot fail an otherwise-successful ingest.
+        adapter.ack()
+
+    def test_fetch_requests_ack_mode(self):
+        adapter = _make_adapter(api_url="http://helper:7123", api_key="k")
+        adapter._client.get.return_value = _make_mock_response([])
+        list(adapter.fetch(""))
+        _, kwargs = adapter._client.get.call_args
+        assert kwargs["params"].get("ack") == "true"


### PR DESCRIPTION
Follow-up to #558. Fixes a commit-ack interaction surfaced during post-deploy verification: a push-driven adapter whose single-page ingest exceeds the mac's 120s push timeout never reaches `ack()`, so its cursor stays staged and the page re-serves (observed for **music** — a 200-track page is ~400 embedding items).

- **music** and **obsidian** → `background_poll = True` (poller-driven; the poller isn't time-bounded, so commit-ack advances cleanly). They're skipped on the broadcast push by the existing race guard. Left **health/imessage/contacts** on the push path — their pages are small and ack within the timeout, and push keeps them near-instant.
- **obsidian** was also *missing commit-ack entirely* (committed on serve, same gap music had). Added `RemoteAdapter.ack()` (best-effort `POST /collectors/{name}/ack`, mirrors `reset()`) and obsidian now fetches with `ack=true`.

Verified in-container: 249 tests pass across the affected adapter/server suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
