### PR TITLE
fix(poller): per-adapter scheduling — the per-source model never polled anything

### DIFF
--- a/src/context_library/adapters/filesystem_helper.py
+++ b/src/context_library/adapters/filesystem_helper.py
@@ -192,12 +192,12 @@ class FilesystemHelperAdapter(RemoteAdapter):
         The internal cursor is advanced to each page's ``next_cursor`` as soon as
         that page's meta line is seen, so a crash mid-drain resumes correctly.
 
-        The opaque cursor is authoritative: the per-source ``source_ref`` passed by
-        the poller (a file path, not a cursor) is ignored in favour of the persisted
-        cursor unless an explicit, non-empty cursor override is supplied.
+        The persisted opaque cursor is authoritative: ``source_ref`` is ignored —
+        callers pass since-timestamps or per-file origin_refs, which are not
+        change-sequence cursors. Use reset() for a full replay.
 
         Args:
-            source_ref: Opaque cursor string (empty = start from the persisted cursor)
+            source_ref: Ignored (see above); part of the BaseAdapter interface.
             extra_body: Optional additional fields merged into the JSON request body.
 
         Yields:
@@ -207,16 +207,19 @@ class FilesystemHelperAdapter(RemoteAdapter):
         Raises:
             httpx.HTTPStatusError: on non-2xx responses
             ValueError: if a line cannot be parsed as JSON
+            RuntimeError: if the stream ends without a meta line (truncated response)
             pydantic.ValidationError: if a content line fails NormalizedContent validation
         """
         headers: dict = {}
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
 
-        # An explicit, non-empty source_ref overrides the persisted cursor (e.g. a
-        # forced replay). Otherwise the persisted cursor is authoritative — the
-        # poller passes per-file origin_refs as source_ref, which are NOT cursors.
-        cursor = source_ref if source_ref else self._cursor
+        # The persisted cursor is always authoritative. source_ref is deliberately
+        # ignored: callers pass since-timestamps (push route) or per-file
+        # origin_refs, neither of which is a filesystem change-sequence cursor —
+        # sending one to the helper would corrupt paging. A full replay is done
+        # via reset(), which clears the helper-side cursor and self._cursor.
+        cursor = self._cursor
 
         # Commit-ack: pull with ?ack=true so the helper stages (rather than commits)
         # its cursor advance; the caller invokes the inherited RemoteAdapter.ack()
@@ -300,15 +303,17 @@ class FilesystemHelperAdapter(RemoteAdapter):
                     yield nc
 
             if not saw_meta:
-                # Stream ended without a meta line — treat as the end of the drain
-                # to avoid an infinite loop, but surface it: the helper violated the
-                # contract (META line is always last).
-                logger.warning(
-                    "FilesystemHelperAdapter: stream ended without a meta line; "
-                    "stopping drain (cursor=%s)",
-                    cursor,
+                # Stream ended without a meta line: the response was truncated
+                # (the META line is always last in the helper's contract). Raise
+                # so the caller does NOT ack — the helper's staged cursor stays
+                # uncommitted and the whole page is re-served on the next poll.
+                # Returning normally here would commit the cursor past content
+                # that was never received.
+                raise RuntimeError(
+                    "FilesystemHelperAdapter: NDJSON stream ended without a meta "
+                    f"line (truncated response, cursor={cursor}); aborting drain "
+                    "so the page is re-served instead of acked"
                 )
-                return
 
             if not has_more:
                 return

--- a/src/context_library/scheduler/poller.py
+++ b/src/context_library/scheduler/poller.py
@@ -1,7 +1,8 @@
-"""Polling-based ingestion trigger; manages per-source poll intervals."""
+"""Polling-based ingestion trigger; schedules registered PULL adapters per-adapter."""
 
 import logging
 import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
@@ -15,7 +16,6 @@ from context_library.domains.base import BaseDomain
 from context_library.scheduler.exceptions import (
     PollerNotRunningError,
     AdapterNotRegisteredError,
-    NoSourcesError,
     IngestAlreadyInProgressError,
 )
 
@@ -120,17 +120,28 @@ class SourceErrorTracker:
 
 
 class Poller:
-    """Background scheduler that periodically polls pull-based sources for updates.
+    """Background scheduler that periodically polls registered PULL adapters.
 
-    Manages a background thread that checks for sources due for re-ingestion based on
-    their configured poll intervals. Provides clean lifecycle management via start/stop.
+    Manages a background thread that runs one ingest per registered adapter when
+    that adapter's poll interval has elapsed. Provides clean lifecycle management
+    via start/stop.
+
+    Scheduling is per-adapter, not per-source: helper adapters drain all of their
+    changed sources in a single fetch() from their own persisted cursor, so the
+    unit of schedulable work is the adapter. (An earlier design scheduled from
+    sources.poll_interval_sec rows, but nothing ever populated that column, so no
+    source was ever due and registered adapters were never polled. Per-adapter
+    scheduling also bootstraps adapters that have no source rows yet.)
 
     Key features:
-    - Reads poll_interval_sec and last_fetched_at from DocumentStore to identify due sources
-    - Delegates to IngestionPipeline which invokes adapter.fetch() for each due source
-    - Updates last_fetched_at after successful ingestion
-    - Isolates per-source failures — one failing source doesn't prevent others from being polled
-    - Only processes sources with poll_strategy = 'pull'
+    - Polls each registered adapter every poll_interval_sec (adapter attribute,
+      defaulting to the poller tick interval) after its last successful run
+    - Delegates to IngestionPipeline (adapter.fetch() drains from the adapter's
+      own cursor) and calls adapter.ack() after the pipeline commits
+    - Isolates per-adapter failures — one failing adapter doesn't prevent others
+      from being polled; failures retry on the next tick with escalating logging
+    - Exposes the per-adapter in-progress flag (try_begin_ingest/end_ingest) so
+      the push route and manual triggers cannot race a running poll
     - Uses a single background threading.Thread with tick-based loop
     - Clean shutdown via threading.Event
     """
@@ -161,8 +172,10 @@ class Poller:
         self._registered: list[tuple[BaseAdapter, BaseDomain]] = []
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
-        # Track per-source error state for escalation
+        # Track per-adapter error state for escalation
         self._error_tracker: dict[str, SourceErrorTracker] = {}
+        # Monotonic timestamp of each adapter's last successful poll
+        self._last_polled: dict[str, float] = {}
         # Prevent concurrent ingest of the same adapter
         self._ingest_in_progress: dict[str, bool] = {}
         # Track background ingest threads for graceful shutdown
@@ -285,152 +298,156 @@ class Poller:
         while not self._stop_event.wait(timeout=self._tick_interval):
             self._tick()
 
+    def try_begin_ingest(self, adapter_id: str) -> bool:
+        """Atomically claim the per-adapter ingest slot.
+
+        Shared by the poller tick, trigger_immediate_ingest(), and the push route
+        (targeted ``?adapter_id=``) so no two paths ingest the same adapter
+        concurrently: concurrent runs share one adapter instance and would race
+        its in-memory cursor and interleave ack() against the same helper
+        collector (commit_push_cursors is collector-global on the helper).
+
+        Returns:
+            True if the slot was claimed — the caller MUST call end_ingest()
+            when done. False if an ingest is already in progress.
+        """
+        with self._threads_lock:
+            if self._ingest_in_progress.get(adapter_id, False):
+                return False
+            self._ingest_in_progress[adapter_id] = True
+            return True
+
+    def end_ingest(self, adapter_id: str) -> None:
+        """Release the per-adapter ingest slot claimed by try_begin_ingest()."""
+        with self._threads_lock:
+            self._ingest_in_progress[adapter_id] = False
+
     def _tick(self) -> None:
         """Single polling cycle (internal).
 
-        Queries the document store for sources due for polling and attempts to ingest each one.
-        Per-source errors are caught, logged, and do not prevent other sources from being polled.
+        Runs one ingest for each registered adapter whose poll interval has
+        elapsed. Per-adapter errors are caught, logged, and do not prevent other
+        adapters from being polled.
 
-        Error escalation:
-        - Tracks consecutive failures per source
+        An adapter is due when poll_interval_sec (adapter attribute, defaulting
+        to the poller tick interval) has elapsed since its last *successful*
+        run. A failed run leaves the last-polled mark unchanged, so the adapter
+        retries on the next tick.
+
+        Error escalation (consecutive failures per adapter):
         - 1-2 failures: INFO level (transient issues expected)
         - 3-5 failures: WARNING level (persistent issue)
         - 6+ failures: ERROR level (critical, may be permanently broken)
 
-        Memory management:
-        - Prunes error tracker entries for sources no longer due for polling
-        - Prevents unbounded growth of _error_tracker dict over time
-
-        CRITICAL: update_last_fetched_at is only called if ingest succeeds. If ingest succeeds
-        but update_last_fetched_at fails, the source will be re-polled on the next tick (acceptable).
-        If ingest fails, update_last_fetched_at is NOT called, so the source remains due for re-polling
-        on the next tick (allowing retry without preventing the scheduler from progressing).
+        The in-progress flag is held for the whole ingest+ack so the push route
+        and manual triggers cannot run the same adapter concurrently.
         """
         with tracer.start_as_current_span("scheduler.poll") as tick_span:
-            due_sources = self._document_store.get_sources_due_for_poll()
-            due_source_ids = {source["source_id"] for source in due_sources}
-
-            tick_span.set_attribute("sources_due_count", len(due_sources))
             tick_span.set_attribute("adapters_registered", len(self._registered))
+            adapters_polled = 0
 
-            # Clean up error tracker entries for sources no longer due for polling.
-            # Note: A source that just succeeded and updated last_fetched_at won't appear in
-            # due_sources until its poll interval elapses again, so its error tracker entry will
-            # be pruned here. This is the desired behavior since clear() already resets state on success.
-            # Entries for removed/deleted sources are also pruned here, allowing failure history
-            # to be implicitly forgotten when sources are no longer in the system.
-            # (prevents unbounded growth of _error_tracker dict)
-            sources_to_remove = set(self._error_tracker.keys()) - due_source_ids
-            for source_id in sources_to_remove:
-                del self._error_tracker[source_id]
+            for adapter, chunker in self._registered:
+                if self._stop_event.is_set():
+                    break
 
-            for source in due_sources:
-                source_id = source["source_id"]
-                adapter_id = source["adapter_id"]
+                adapter_id = adapter.adapter_id
+                interval = getattr(adapter, "poll_interval_sec", None) or self._tick_interval
+                last = self._last_polled.get(adapter_id)
+                if last is not None and (time.monotonic() - last) < interval:
+                    continue
 
-                # Skip if a background ingest is already in progress for this adapter
-                with self._threads_lock:
-                    if self._ingest_in_progress.get(adapter_id, False):
-                        logger.debug(
-                            "Poller: skipping source %s; background ingest in progress for adapter %s",
-                            source_id,
-                            adapter_id,
-                        )
-                        continue
-
-                adapter, chunker = self._find_adapter(adapter_id)
-                if adapter is None or chunker is None:
-                    logger.warning(
-                        "Poller: no registered adapter found for adapter_id=%s",
+                if not self.try_begin_ingest(adapter_id):
+                    logger.debug(
+                        "Poller: skipping adapter %s; ingest already in progress",
                         adapter_id,
                     )
                     continue
 
-                # Initialize error tracker for this source if needed
-                if source_id not in self._error_tracker:
-                    self._error_tracker[source_id] = SourceErrorTracker()
+                if adapter_id not in self._error_tracker:
+                    self._error_tracker[adapter_id] = SourceErrorTracker()
 
-                with tracer.start_as_current_span("scheduler.poll.source") as source_span:
-                    source_span.set_attribute("source_id", source_id)
-                    source_span.set_attribute("adapter_id", adapter_id)
+                with tracer.start_as_current_span("scheduler.poll.adapter") as adapter_span:
+                    adapter_span.set_attribute("adapter_id", adapter_id)
 
                     try:
-                        self._pipeline.ingest(adapter, chunker, source_ref=source["origin_ref"])
+                        # source_ref="" — the adapter drains from its own
+                        # persisted cursor; per-source origin_refs are not
+                        # cursors and must not be passed here.
+                        self._pipeline.ingest(adapter, chunker, source_ref="")
                         # Commit-ack: confirm to the helper that the page was durably
                         # persisted so it advances its staged delivery cursor (no-op
                         # for adapters not using commit-ack; best-effort, never raises).
                         adapter.ack()
-                        # Clear error tracking on successful ingestion
-                        self._error_tracker[source_id].clear()
+                        self._error_tracker[adapter_id].clear()
+                        self._last_polled[adapter_id] = time.monotonic()
+                        adapters_polled += 1
                     except MemoryError:
                         # System-level memory exhaustion is fatal; propagate immediately
                         raise
                     except Exception as e:
-                        error_tracker = self._error_tracker[source_id]
+                        error_tracker = self._error_tracker[adapter_id]
                         error_msg = f"ingest failed: {e}"
                         error_tracker.record_failure()
 
-                        source_span.set_status(StatusCode.ERROR)
-                        source_span.record_exception(e)
-                        source_span.set_attribute("error.consecutive_failures", error_tracker.consecutive_failures)
+                        adapter_span.set_status(StatusCode.ERROR)
+                        adapter_span.record_exception(e)
+                        adapter_span.set_attribute("error.consecutive_failures", error_tracker.consecutive_failures)
 
                         # Programming bugs (TypeError, AttributeError, etc.) indicate code issues
                         # that won't be fixed by retrying. Log them at ERROR level immediately
                         # rather than waiting for 6+ cycles.
                         if _is_programming_error(e):
                             logger.error(
-                                "Poller: source %s encountered a programming error (escalated immediately): %s",
-                                source_id,
+                                "Poller: adapter %s encountered a programming error (escalated immediately): %s",
+                                adapter_id,
                                 error_msg,
                                 exc_info=True,
                             )
                         # Log at escalated level based on consecutive failure count for transient errors
                         elif error_tracker.should_log_at_error_level():
                             logger.error(
-                                "Poller: source %s has failed %d times (ERROR level): %s",
-                                source_id,
+                                "Poller: adapter %s has failed %d times (ERROR level): %s",
+                                adapter_id,
                                 error_tracker.consecutive_failures,
                                 error_msg,
                             )
                         elif error_tracker.should_log_at_warning_level():
                             logger.warning(
-                                "Poller: source %s has failed %d times (WARNING level): %s",
-                                source_id,
+                                "Poller: adapter %s has failed %d times (WARNING level): %s",
+                                adapter_id,
                                 error_tracker.consecutive_failures,
                                 error_msg,
                             )
                         else:
                             logger.info(
-                                "Poller: source %s ingestion attempt failed (transient): %s",
-                                source_id,
+                                "Poller: adapter %s ingestion attempt failed (transient): %s",
+                                adapter_id,
                                 error_msg,
                             )
-                        continue
+                    finally:
+                        self.end_ingest(adapter_id)
 
-                    # Only update last_fetched_at if ingest succeeded
-                    try:
-                        self._document_store.update_last_fetched_at(source_id)
-                    except Exception as e:
-                        logger.exception(
-                            "Poller: failed to update last_fetched_at for source %s: %s",
-                            source_id,
-                            e,
-                        )
+            tick_span.set_attribute("adapters_polled", adapters_polled)
 
     def trigger_immediate_ingest(self, adapter_id: str) -> bool:
         """Trigger an immediate, one-shot ingest run for a specific adapter.
 
         Finds the registered (adapter, chunker) pair for the given adapter_id and
-        schedules all sources registered to that adapter for immediate re-ingestion,
-        bypassing the normal poll-interval gate. The ingest runs asynchronously
-        in a background thread, allowing the HTTP response to return immediately.
+        runs one ingest for it immediately, bypassing the poll-interval gate. The
+        ingest runs asynchronously in a background thread, allowing the HTTP
+        response to return immediately.
 
-        Prevents concurrent ingest of the same adapter using a busy flag. If an ingest
-        is already in progress for this adapter, raises IngestAlreadyInProgressError.
+        The adapter drains from its own persisted cursor (source_ref=""), so this
+        also works for a freshly registered adapter with no source rows yet — the
+        bootstrap case a manual trigger exists for. After the pipeline commits,
+        adapter.ack() confirms delivery to the helper so its staged cursor
+        advances (previously manual triggers never acked, leaving the helper
+        cursor staged until the next scheduled poll).
 
-        Background threads are tracked and joined during shutdown to ensure graceful
-        cleanup. Per-source failures are logged with exc_info and the result is stored
-        in _ingest_results for querying (via get_ingest_result).
+        Prevents concurrent ingest of the same adapter via the shared per-adapter
+        ingest slot (try_begin_ingest). Background threads are tracked and joined
+        during shutdown. The result is stored in _ingest_results for querying
+        (via get_ingest_result).
 
         Args:
             adapter_id: The adapter ID to trigger ingest for
@@ -441,7 +458,6 @@ class Poller:
         Raises:
             PollerNotRunningError: If the poller is stopped or not running
             AdapterNotRegisteredError: If the adapter is not registered with the poller
-            NoSourcesError: If no sources are registered to the adapter
             IngestAlreadyInProgressError: If an ingest is already in progress for this adapter
         """
         # Raise if poller is stopped or not started
@@ -453,75 +469,63 @@ class Poller:
         if adapter is None or chunker is None:
             raise AdapterNotRegisteredError(f"Adapter '{adapter_id}' is not registered")
 
-        # Get all sources for this adapter
-        sources = self._document_store.get_sources_for_adapter(adapter_id)
-        if not sources:
-            raise NoSourcesError(f"No sources found for adapter '{adapter_id}'")
-
-        # Check-and-set the ingest_in_progress flag atomically
-        # This prevents TOCTOU race where two threads could both pass the check
-        with self._threads_lock:
-            if self._ingest_in_progress.get(adapter_id, False):
-                logger.warning(
-                    "trigger_immediate_ingest: ingest already in progress for adapter %s",
-                    adapter_id,
-                )
-                raise IngestAlreadyInProgressError(
-                    f"Ingest is already in progress for adapter '{adapter_id}'"
-                )
-            # Mark this adapter as having an ingest in progress
-            self._ingest_in_progress[adapter_id] = True
+        # Claim the shared per-adapter ingest slot (atomic check-and-set; also
+        # blocks the poller tick and the push route while this run is active).
+        if not self.try_begin_ingest(adapter_id):
+            logger.warning(
+                "trigger_immediate_ingest: ingest already in progress for adapter %s",
+                adapter_id,
+            )
+            raise IngestAlreadyInProgressError(
+                f"Ingest is already in progress for adapter '{adapter_id}'"
+            )
 
         # Capture OTel context from the calling thread (HTTP request) so the
         # background thread's spans are parented to the incoming request trace.
         _ingest_ctx = tel.capture_context()
 
-        # Spawn a background thread to process sources immediately (non-blocking)
-        def process_sources() -> None:
+        # Spawn a background thread to run the ingest immediately (non-blocking)
+        def process_adapter() -> None:
             with tel.run_in_context(_ingest_ctx):
                 with tracer.start_as_current_span("scheduler.poll.immediate") as immediate_span:
                     immediate_span.set_attribute("adapter_id", adapter_id)
                     immediate_span.set_attribute("trigger", "manual")
 
-                    result = IngestResult(adapter_id=adapter_id, sources_attempted=len(sources))
+                    result = IngestResult(adapter_id=adapter_id)
                     try:
-                        for source in sources:
-                            source_id = source["source_id"]
-                            try:
-                                self._pipeline.ingest(
-                                    adapter, chunker, source_ref=source["origin_ref"]
-                                )
-                                result.sources_succeeded += 1
-                                # Update last_fetched_at on successful ingest
-                                try:
-                                    self._document_store.update_last_fetched_at(source_id)
-                                except Exception as e:
-                                    logger.exception(
-                                        "trigger_immediate_ingest: failed to update last_fetched_at "
-                                        "for source %s: %s",
-                                        source_id,
-                                        e,
-                                    )
-                            except MemoryError:
-                                # System-level memory exhaustion is fatal; propagate immediately
-                                raise
-                            except Exception as e:
-                                result.sources_failed += 1
-                                # Detect programming errors and flag them
-                                if _is_programming_error(e):
-                                    result.had_programming_errors = True
-                                    logger.error(
-                                        "trigger_immediate_ingest: source %s encountered a programming error: %s",
-                                        source_id,
-                                        e,
-                                        exc_info=True,
-                                    )
-                                else:
-                                    logger.exception(
-                                        "trigger_immediate_ingest: ingest failed for source %s: %s",
-                                        source_id,
-                                        e,
-                                    )
+                        ingest_result = self._pipeline.ingest(
+                            adapter, chunker, source_ref=""
+                        )
+                        # Commit-ack: confirm to the helper that the page was durably
+                        # persisted so it advances its staged delivery cursor (no-op
+                        # for adapters not using commit-ack; best-effort, never raises).
+                        adapter.ack()
+                        processed = ingest_result.get("sources_processed", 0)
+                        failed = ingest_result.get("sources_failed", 0)
+                        result.sources_attempted = processed + failed
+                        result.sources_succeeded = processed
+                        result.sources_failed = failed
+                        self._last_polled[adapter_id] = time.monotonic()
+                    except MemoryError:
+                        # System-level memory exhaustion is fatal; propagate immediately
+                        raise
+                    except Exception as e:
+                        result.sources_attempted = max(result.sources_attempted, 1)
+                        result.sources_failed = max(result.sources_failed, 1)
+                        if _is_programming_error(e):
+                            result.had_programming_errors = True
+                            logger.error(
+                                "trigger_immediate_ingest: adapter %s encountered a programming error: %s",
+                                adapter_id,
+                                e,
+                                exc_info=True,
+                            )
+                        else:
+                            logger.exception(
+                                "trigger_immediate_ingest: ingest failed for adapter %s: %s",
+                                adapter_id,
+                                e,
+                            )
                     finally:
                         # Mark result as completed and store it
                         result.completed_at = datetime.now()
@@ -540,7 +544,7 @@ class Poller:
                             self._ingest_thread_adapters.pop(threading.current_thread(), None)
 
         # Use non-daemon threads and track them for graceful shutdown
-        thread = threading.Thread(target=process_sources, daemon=False)
+        thread = threading.Thread(target=process_adapter, daemon=False)
         with self._threads_lock:
             self._background_threads.add(thread)
             self._ingest_thread_adapters[thread] = adapter_id

--- a/src/context_library/scheduler/poller.py
+++ b/src/context_library/scheduler/poller.py
@@ -23,6 +23,18 @@ logger = logging.getLogger(__name__)
 tracer = get_tracer(__name__)
 StatusCode = get_status_code()
 
+_meter = tel.get_meter("context_library.poller")
+# Heartbeat counters: alert on ABSENCE of ticks/polls in SigNoz — the July
+# 2026 outage was a poller that registered adapters and then never polled.
+_tick_counter = _meter.create_counter(
+    "context_library.poller.ticks_total",
+    description="Poller tick cycles executed",
+)
+_poll_counter = _meter.create_counter(
+    "context_library.poller.adapter_polls_total",
+    description="Per-adapter poll ingests executed (status=ok|error)",
+)
+
 
 def _is_programming_error(exc: Exception) -> bool:
     """Detect programming bugs that should escalate to ERROR level immediately.
@@ -344,6 +356,7 @@ class Poller:
         """
         with tracer.start_as_current_span("scheduler.poll") as tick_span:
             tick_span.set_attribute("adapters_registered", len(self._registered))
+            _tick_counter.add(1)
             adapters_polled = 0
 
             for adapter, chunker in self._registered:
@@ -381,6 +394,7 @@ class Poller:
                         self._error_tracker[adapter_id].clear()
                         self._last_polled[adapter_id] = time.monotonic()
                         adapters_polled += 1
+                        _poll_counter.add(1, {"adapter_id": adapter_id, "status": "ok"})
                     except MemoryError:
                         # System-level memory exhaustion is fatal; propagate immediately
                         raise
@@ -388,6 +402,7 @@ class Poller:
                         error_tracker = self._error_tracker[adapter_id]
                         error_msg = f"ingest failed: {e}"
                         error_tracker.record_failure()
+                        _poll_counter.add(1, {"adapter_id": adapter_id, "status": "error"})
 
                         adapter_span.set_status(StatusCode.ERROR)
                         adapter_span.record_exception(e)

--- a/src/context_library/server/routes/ingest.py
+++ b/src/context_library/server/routes/ingest.py
@@ -207,6 +207,7 @@ async def helper_ingest(
                 raise HTTPException(status_code=422, detail=f"Invalid 'since' value: {since!r} — expected ISO 8601 timestamp")
 
         source_ref = "" if full else (since or "")
+        poller = getattr(request.app.state, "poller", None)
 
         results = []
         for adapter in helper_adapters:
@@ -217,6 +218,29 @@ async def helper_ingest(
             # collector-global on the helper). A targeted ?adapter_id= still runs them,
             # so manual full re-ingests keep working.
             if adapter_id is None and getattr(adapter, "background_poll", False):
+                continue
+            # Claim the shared per-adapter ingest slot so this request cannot run
+            # concurrently with the poller tick or a manual trigger on the same
+            # adapter instance (they would race its in-memory cursor and ack).
+            if poller is not None and not poller.try_begin_ingest(adapter.adapter_id):
+                logger.warning(
+                    "helper_ingest: skipping adapter %s — ingest already in progress",
+                    adapter.adapter_id,
+                )
+                results.append(AppleAdapterResult(
+                    adapter_id=adapter.adapter_id,
+                    status="skipped",
+                    sources_processed=0,
+                    sources_failed=0,
+                    chunks_added=0,
+                    chunks_removed=0,
+                    chunks_unchanged=0,
+                    errors=[IngestError(
+                        source_id="",
+                        error_type="IngestAlreadyInProgress",
+                        message="an ingest for this adapter is already running (poller or manual trigger); skipped",
+                    )],
+                ))
                 continue
             domain_chunker = get_domain_chunker(adapter.domain)
             try:
@@ -268,6 +292,9 @@ async def helper_ingest(
                     chunks_unchanged=0,
                     errors=[IngestError(source_id="", error_type=type(e).__name__, message=str(e))],
                 ))
+            finally:
+                if poller is not None:
+                    poller.end_ingest(adapter.adapter_id)
 
         span.set_attribute("ingest.adapters_run", len(results))
         span.set_attribute("ingest.chunks_added", sum(r.chunks_added for r in results))

--- a/tests/adapters/test_filesystem_helper.py
+++ b/tests/adapters/test_filesystem_helper.py
@@ -218,11 +218,13 @@ class TestFilesystemHelperAdapterFetch:
         assert rec.calls[0]["method"] == "POST"
         assert rec.calls[0]["url"].endswith("/filesystem/fetch")
 
-    def test_fetch_sends_source_ref_in_body(self):
+    def test_fetch_sends_persisted_cursor_in_body(self):
+        """The request body carries the adapter's persisted cursor, not the caller's source_ref."""
         adapter = self._make_adapter()
+        adapter._cursor = "42"
         rec = _StreamRecorder([[_make_meta_line()]])
         with patch.object(adapter._client, "stream", side_effect=rec):
-            list(adapter.fetch("42"))
+            list(adapter.fetch(""))
         assert rec.calls[0]["json"]["source_ref"] == "42"
 
     def test_fetch_sends_stream_true_in_body(self):
@@ -370,23 +372,69 @@ class TestFilesystemHelperAdapterDrain:
             list(adapter.fetch(""))
         assert second.calls[0]["json"]["source_ref"] == "55"
 
-    def test_explicit_source_ref_overrides_persisted_cursor(self):
-        """A non-empty source_ref (forced replay) overrides the persisted cursor."""
+    def test_source_ref_is_ignored_in_favor_of_persisted_cursor(self):
+        """source_ref is deliberately ignored: the persisted cursor is authoritative.
+
+        Callers pass since-timestamps or per-file origin_refs as source_ref,
+        which are not change-sequence cursors — sending one to the helper would
+        corrupt paging. A full replay is done via reset(), not via source_ref.
+        """
         adapter = self._make_adapter()
         adapter._cursor = "99"
         rec = _StreamRecorder([[_make_meta_line(has_more=False, next_cursor="100")]])
         with patch.object(adapter._client, "stream", side_effect=rec):
             list(adapter.fetch("7"))
-        assert rec.calls[0]["json"]["source_ref"] == "7"
+        assert rec.calls[0]["json"]["source_ref"] == "99"
 
-    def test_stream_without_meta_line_stops_drain(self):
-        """A page that ends without a meta line stops the drain (no infinite loop)."""
+    def test_source_ref_ignored_even_when_no_cursor_persisted(self):
+        """With no persisted cursor, a non-empty source_ref still is not sent."""
+        adapter = self._make_adapter()
+        rec = _StreamRecorder([[_make_meta_line(has_more=False, next_cursor="1")]])
+        with patch.object(adapter._client, "stream", side_effect=rec):
+            list(adapter.fetch("2026-01-01T00:00:00+00:00"))  # push-route since-timestamp
+        assert rec.calls[0]["json"]["source_ref"] == ""
+
+    def test_truncated_stream_raises_runtime_error(self):
+        """A stream that ends without a meta line raises RuntimeError.
+
+        Returning normally would let the caller ack a page that was never fully
+        received, committing the helper's staged cursor past lost content. The
+        raise keeps the staged cursor uncommitted so the page is re-served.
+        """
         adapter = self._make_adapter()
         rec = _StreamRecorder([[_make_content_line("a.md")]])  # no meta line
         with patch.object(adapter._client, "stream", side_effect=rec):
-            results = list(adapter.fetch(""))
-        assert [r.source_id for r in results] == ["a.md"]
+            with pytest.raises(RuntimeError, match="without a meta"):
+                list(adapter.fetch(""))
         assert len(rec.calls) == 1
+
+    def test_truncated_stream_does_not_advance_cursor(self):
+        """A truncated page must not advance the persisted cursor."""
+        adapter = self._make_adapter()
+        adapter._cursor = "10"
+        rec = _StreamRecorder([[_make_content_line("a.md")]])  # no meta line
+        with patch.object(adapter._client, "stream", side_effect=rec):
+            with pytest.raises(RuntimeError):
+                list(adapter.fetch(""))
+        assert adapter._cursor == "10"
+
+    def test_truncation_on_later_page_raises_after_earlier_pages(self):
+        """Truncation mid-drain raises, but earlier complete pages were consumed
+        and their cursor advance is preserved (crash-resume semantics)."""
+        adapter = self._make_adapter()
+        pages = [
+            [_make_content_line("a.md"), _make_meta_line(has_more=True, next_cursor="1")],
+            [_make_content_line("b.md")],  # truncated second page
+        ]
+        rec = _StreamRecorder(pages)
+        collected = []
+        with patch.object(adapter._client, "stream", side_effect=rec):
+            with pytest.raises(RuntimeError):
+                for item in adapter.fetch(""):
+                    collected.append(item.source_id)
+        assert collected == ["a.md", "b.md"]
+        # Cursor persisted at the last fully-streamed page's next_cursor.
+        assert adapter._cursor == "1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scheduler/test_poller.py
+++ b/tests/scheduler/test_poller.py
@@ -1,4 +1,11 @@
-"""Tests for the scheduler poller."""
+"""Tests for the scheduler poller (per-adapter scheduling).
+
+The Poller schedules registered (adapter, chunker) pairs directly: an adapter is
+due when its poll_interval_sec (or the poller tick interval) has elapsed since
+its last *successful* run. It never queries the document store for per-source
+poll rows, always passes source_ref="" to the pipeline (adapters drain from
+their own persisted cursor), and calls adapter.ack() after a successful commit.
+"""
 import os
 
 import tempfile
@@ -16,6 +23,28 @@ from context_library.domains.base import BaseDomain
 from context_library.scheduler.poller import Poller
 from context_library.storage.document_store import DocumentStore
 from context_library.storage.models import Domain, NormalizedContent
+
+
+#: Minimal pipeline.ingest() result dict as returned on success.
+def _pipeline_result(processed: int = 1, failed: int = 0) -> dict:
+    return {
+        "sources_processed": processed,
+        "sources_failed": failed,
+        "chunks_added": 0,
+        "chunks_removed": 0,
+        "chunks_unchanged": 0,
+        "errors": [],
+    }
+
+
+def _wait_for(predicate, timeout: float = 3.0, interval: float = 0.01) -> bool:
+    """Poll predicate until true or timeout; returns final predicate value."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return bool(predicate())
 
 
 class MockAdapter(BaseAdapter):
@@ -172,34 +201,28 @@ class TestPollerLifecycle:
         """start() should spawn a daemon thread."""
         poller = Poller(pipeline, document_store, tick_interval=0.5)
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            poller.start()
+        poller.start()
 
-            try:
-                assert poller._thread is not None
-                assert poller._thread.is_alive()
-                assert poller._thread.daemon is True
-            finally:
-                poller.stop()
+        try:
+            assert poller._thread is not None
+            assert poller._thread.is_alive()
+            assert poller._thread.daemon is True
+        finally:
+            poller.stop()
 
     def test_stop_joins_thread(self, pipeline, document_store):
         """stop() should wait for thread to exit."""
         poller = Poller(pipeline, document_store, tick_interval=0.5)
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            poller.start()
+        poller.start()
 
-            assert poller._thread is not None
-            assert poller._thread.is_alive()
+        assert poller._thread is not None
+        assert poller._thread.is_alive()
 
-            poller.stop()
+        poller.stop()
 
-            # After stop(), thread should have exited and _thread should be None
-            assert poller._thread is None
+        # After stop(), thread should have exited and _thread should be None
+        assert poller._thread is None
 
     def test_stop_before_start_no_error(self, pipeline, document_store):
         """Calling stop() before start() should not raise."""
@@ -212,186 +235,275 @@ class TestPollerLifecycle:
         """After stop(), calling start() again should work (event cleared)."""
         poller = Poller(pipeline, document_store, tick_interval=0.1)
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            poller.start()
-            poller.stop()
+        poller.start()
+        poller.stop()
 
-            # Should be able to start again
-            poller.start()
-            try:
-                assert poller._thread is not None
-                assert poller._thread.is_alive()
-            finally:
-                poller.stop()
+        # Should be able to start again
+        poller.start()
+        try:
+            assert poller._thread is not None
+            assert poller._thread.is_alive()
+        finally:
+            poller.stop()
 
     def test_start_already_running_is_noop(self, pipeline, document_store):
         """Calling start() when thread is already running should be a no-op."""
         poller = Poller(pipeline, document_store, tick_interval=0.5)
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            poller.start()
+        poller.start()
 
-            thread1 = poller._thread
-            time.sleep(0.1)
+        thread1 = poller._thread
+        time.sleep(0.1)
 
-            # Call start again
-            poller.start()
-            thread2 = poller._thread
+        # Call start again
+        poller.start()
+        thread2 = poller._thread
 
-            # Should be the same thread
-            assert thread1 is thread2
+        # Should be the same thread
+        assert thread1 is thread2
 
-            poller.stop()
+        poller.stop()
 
     def test_start_stop_cycle_repeatable(self, pipeline, document_store):
         """Poller should be restartable after stop()."""
         poller = Poller(pipeline, document_store, tick_interval=0.1)
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            for _ in range(3):
-                poller.start()
-                time.sleep(0.05)
-                poller.stop()
-                assert poller._thread is None
+        for _ in range(3):
+            poller.start()
+            time.sleep(0.05)
+            poller.stop()
+            assert poller._thread is None
 
 
 class TestPollerTicking:
-    """Tests for polling tick logic."""
+    """Tests for the per-adapter polling tick logic."""
 
-    def test_tick_queries_due_sources(self, pipeline, document_store):
-        """_tick() should query document_store.get_sources_due_for_poll()."""
+    def test_tick_does_not_query_document_store_for_due_sources(
+        self, pipeline, document_store
+    ):
+        """_tick() schedules per-adapter; it never calls get_sources_due_for_poll()."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
         poller = Poller(pipeline, document_store)
+        poller.register(adapter, chunker)
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ) as mock_get_due:
+        with (
+            patch.object(document_store, "get_sources_due_for_poll") as mock_get_due,
+            patch.object(pipeline, "ingest", return_value=_pipeline_result()),
+        ):
             poller._tick()
 
-            mock_get_due.assert_called_once()
+            mock_get_due.assert_not_called()
 
-    def test_tick_ingests_due_sources(self, pipeline, document_store):
-        """_tick() should call pipeline.ingest() for each due source with source_ref."""
+    def test_tick_ingests_registered_adapter_with_empty_source_ref(
+        self, pipeline, document_store
+    ):
+        """_tick() runs one ingest per due adapter with source_ref="" (adapter cursor)."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
         poller = Poller(pipeline, document_store)
         poller.register(adapter, chunker)
 
-        # Mock document_store to return a due source
-        due_source = {
-            "source_id": "source-1",
-            "adapter_id": "test-adapter",
-            "origin_ref": "/path/to/source",
-            "poll_interval_sec": 60,
-            "last_fetched_at": None,
-        }
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()) as mock_ingest:
+            poller._tick()
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[due_source]
-        ):
-            with patch.object(pipeline, "ingest") as mock_ingest:
-                poller._tick()
+            mock_ingest.assert_called_once_with(adapter, chunker, source_ref="")
 
-                mock_ingest.assert_called_once_with(
-                    adapter, chunker, source_ref="/path/to/source"
-                )
+    def test_tick_ingests_all_registered_adapters(self, pipeline, document_store):
+        """_tick() should run one ingest for every registered (due) adapter."""
+        adapter1 = MockAdapter("adapter-1", Domain.NOTES)
+        adapter2 = MockAdapter("adapter-2", Domain.MESSAGES)
+        chunker1 = MockDomain()
+        chunker2 = MockDomain()
 
-    def test_tick_updates_last_fetched_at_on_success(self, pipeline, document_store):
-        """_tick() should call update_last_fetched_at() after successful ingest."""
+        poller = Poller(pipeline, document_store)
+        poller.register(adapter1, chunker1)
+        poller.register(adapter2, chunker2)
+
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()) as mock_ingest:
+            poller._tick()
+
+            assert mock_ingest.call_count == 2
+            called_adapters = [c.args[0] for c in mock_ingest.call_args_list]
+            assert called_adapters == [adapter1, adapter2]
+
+    def test_tick_skips_adapter_within_interval(self, pipeline, document_store):
+        """After a successful run, the adapter is not due again until the interval elapses."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
+        poller = Poller(pipeline, document_store, tick_interval=60.0)
+        poller.register(adapter, chunker)
+
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()) as mock_ingest:
+            poller._tick()
+            poller._tick()  # immediately again — interval (60s) has not elapsed
+
+            mock_ingest.assert_called_once()
+
+    def test_tick_polls_again_after_interval_elapsed(self, pipeline, document_store):
+        """An adapter becomes due again once tick_interval has elapsed since last success."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
+        poller = Poller(pipeline, document_store, tick_interval=60.0)
+        poller.register(adapter, chunker)
+
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()) as mock_ingest:
+            poller._tick()
+            assert mock_ingest.call_count == 1
+
+            # Simulate the interval having elapsed
+            poller._last_polled["test-adapter"] = time.monotonic() - 61.0
+            poller._tick()
+
+            assert mock_ingest.call_count == 2
+
+    def test_tick_respects_adapter_poll_interval_sec_override(
+        self, pipeline, document_store
+    ):
+        """adapter.poll_interval_sec overrides the poller tick_interval for dueness."""
+        fast_adapter = MockAdapter("fast-adapter", Domain.NOTES)
+        fast_adapter.poll_interval_sec = 5.0  # due after 5s despite 60s tick_interval
+        slow_adapter = MockAdapter("slow-adapter", Domain.NOTES)  # defaults to tick_interval
+        chunker = MockDomain()
+
+        poller = Poller(pipeline, document_store, tick_interval=60.0)
+        poller.register(fast_adapter, chunker)
+        poller.register(slow_adapter, chunker)
+
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()) as mock_ingest:
+            poller._tick()
+            assert mock_ingest.call_count == 2  # both due on first tick
+
+            # 10 seconds "ago": past the fast adapter's 5s override,
+            # but well within the slow adapter's 60s default.
+            mark = time.monotonic() - 10.0
+            poller._last_polled["fast-adapter"] = mark
+            poller._last_polled["slow-adapter"] = mark
+            poller._tick()
+
+            assert mock_ingest.call_count == 3
+            assert mock_ingest.call_args_list[-1].args[0] is fast_adapter
+
+    def test_tick_none_poll_interval_falls_back_to_tick_interval(
+        self, pipeline, document_store
+    ):
+        """poll_interval_sec=None falls back to the poller tick_interval."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        adapter.poll_interval_sec = None
+        chunker = MockDomain()
+
+        poller = Poller(pipeline, document_store, tick_interval=60.0)
+        poller.register(adapter, chunker)
+
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()) as mock_ingest:
+            poller._tick()
+            poller._last_polled["test-adapter"] = time.monotonic() - 10.0
+            poller._tick()  # 10s elapsed < 60s tick_interval — not due
+
+            mock_ingest.assert_called_once()
+
+    def test_tick_updates_last_polled_on_success(self, pipeline, document_store):
+        """_tick() records the adapter's last successful poll time."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
         poller = Poller(pipeline, document_store)
         poller.register(adapter, chunker)
 
-        due_source = {
-            "source_id": "source-1",
-            "adapter_id": "test-adapter",
-            "origin_ref": "/path/to/source",
-            "poll_interval_sec": 60,
-            "last_fetched_at": None,
-        }
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()):
+            before = time.monotonic()
+            poller._tick()
+
+        assert "test-adapter" in poller._last_polled
+        assert poller._last_polled["test-adapter"] >= before
+
+    def test_tick_does_not_update_last_polled_on_failure_and_retries(
+        self, pipeline, document_store
+    ):
+        """A failed run leaves _last_polled unset so the adapter retries next tick."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
+        poller = Poller(pipeline, document_store, tick_interval=60.0)
+        poller.register(adapter, chunker)
 
         with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[due_source]
-        ):
-            with patch.object(pipeline, "ingest"):
-                with patch.object(
-                    document_store, "update_last_fetched_at"
-                ) as mock_update:
-                    poller._tick()
+            pipeline,
+            "ingest",
+            side_effect=[Exception("Test error"), _pipeline_result()],
+        ) as mock_ingest:
+            poller._tick()
+            assert "test-adapter" not in poller._last_polled
 
-                    mock_update.assert_called_once_with("source-1")
+            # Failed adapter is immediately due again on the next tick
+            poller._tick()
 
-    def test_tick_handles_missing_adapter(self, pipeline, document_store):
-        """_tick() should handle missing adapter gracefully."""
+            assert mock_ingest.call_count == 2
+            assert "test-adapter" in poller._last_polled
+
+    def test_tick_does_not_call_update_last_fetched_at(self, pipeline, document_store):
+        """The poller no longer touches per-source last_fetched_at (pipeline owns it)."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
         poller = Poller(pipeline, document_store)
+        poller.register(adapter, chunker)
 
-        due_source = {
-            "source_id": "source-1",
-            "adapter_id": "missing-adapter",
-            "origin_ref": "/path/to/source",
-            "poll_interval_sec": 60,
-            "last_fetched_at": None,
-        }
-
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[due_source]
+        with (
+            patch.object(pipeline, "ingest", return_value=_pipeline_result()),
+            patch.object(document_store, "update_last_fetched_at") as mock_update,
         ):
-            with patch.object(pipeline, "ingest") as mock_ingest:
-                # Should not raise
+            poller._tick()
+
+            mock_update.assert_not_called()
+
+    def test_tick_isolates_per_adapter_failures(self, pipeline, document_store):
+        """_tick() should continue polling other adapters after one adapter fails."""
+        adapter1 = MockAdapter("adapter-1", Domain.NOTES)
+        adapter2 = MockAdapter("adapter-2", Domain.MESSAGES)
+        chunker = MockDomain()
+
+        poller = Poller(pipeline, document_store)
+        poller.register(adapter1, chunker)
+        poller.register(adapter2, chunker)
+
+        # First adapter's ingest raises, second succeeds
+        pipeline.ingest = Mock(side_effect=[Exception("Test error"), _pipeline_result()])
+
+        # Should not raise
+        poller._tick()
+
+        assert pipeline.ingest.call_count == 2
+        # Only the successful adapter got a last-polled mark
+        assert "adapter-1" not in poller._last_polled
+        assert "adapter-2" in poller._last_polled
+
+    def test_tick_skips_adapter_when_ingest_in_progress(self, pipeline, document_store):
+        """_tick() skips (with a debug log) an adapter whose ingest slot is busy."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
+        poller = Poller(pipeline, document_store)
+        poller.register(adapter, chunker)
+
+        # Claim the slot as another path (push route / manual trigger) would
+        assert poller.try_begin_ingest("test-adapter") is True
+        try:
+            with (
+                patch.object(pipeline, "ingest") as mock_ingest,
+                patch("context_library.scheduler.poller.logger") as mock_logger,
+            ):
                 poller._tick()
 
-                # Should not have called ingest
                 mock_ingest.assert_not_called()
-
-    def test_tick_isolates_per_source_failures(self, pipeline, document_store):
-        """_tick() should continue processing after one source fails."""
-        adapter = MockAdapter("test-adapter", Domain.NOTES)
-        chunker = MockDomain()
-
-        poller = Poller(pipeline, document_store)
-        poller.register(adapter, chunker)
-
-        due_sources = [
-            {
-                "source_id": "source-1",
-                "adapter_id": "test-adapter",
-                "origin_ref": "/path/to/source-1",
-                "poll_interval_sec": 60,
-                "last_fetched_at": None,
-            },
-            {
-                "source_id": "source-2",
-                "adapter_id": "test-adapter",
-                "origin_ref": "/path/to/source-2",
-                "poll_interval_sec": 60,
-                "last_fetched_at": None,
-            },
-        ]
-
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=due_sources
-        ):
-            # Make first ingest raise, second succeed
-            pipeline.ingest = Mock(side_effect=[Exception("Test error"), {}])
-
-            with patch.object(
-                document_store, "update_last_fetched_at"
-            ) as mock_update:
-                # Should not raise
-                poller._tick()
-
-                # Both sources should have been attempted
-                assert pipeline.ingest.call_count == 2
-                # update_last_fetched_at should only be called for the successful source
-                mock_update.assert_called_once_with("source-2")
+                mock_logger.debug.assert_called_once()
+                assert "already in progress" in str(mock_logger.debug.call_args)
+        finally:
+            poller.end_ingest("test-adapter")
 
     def test_tick_logs_failure_at_info_level_on_first_failure(
         self, pipeline, document_store
@@ -403,111 +515,123 @@ class TestPollerTicking:
         poller = Poller(pipeline, document_store)
         poller.register(adapter, chunker)
 
-        due_source = {
-            "source_id": "source-1",
-            "adapter_id": "test-adapter",
-            "origin_ref": "/path/to/source",
-            "poll_interval_sec": 60,
-            "last_fetched_at": None,
-        }
+        with patch.object(pipeline, "ingest", side_effect=Exception("Test error")):
+            with patch("context_library.scheduler.poller.logger") as mock_logger:
+                poller._tick()
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[due_source]
-        ):
-            with patch.object(pipeline, "ingest", side_effect=Exception("Test error")):
-                with patch("context_library.scheduler.poller.logger") as mock_logger:
-                    poller._tick()
-
-                    # First failure should log at INFO level (transient)
-                    mock_logger.info.assert_called_once()
-                    call_args = str(mock_logger.info.call_args)
-                    assert "source-1" in call_args
-                    assert "transient" in call_args
+                # First failure should log at INFO level (transient)
+                mock_logger.info.assert_called_once()
+                call_args = str(mock_logger.info.call_args)
+                assert "test-adapter" in call_args
+                assert "transient" in call_args
 
     def test_tick_logs_failure_at_warning_level_after_3_failures(
         self, pipeline, document_store
     ):
-        """_tick() should log at WARNING level after 3 consecutive failures."""
+        """_tick() should log at WARNING level after 3 consecutive adapter failures."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
         poller = Poller(pipeline, document_store)
         poller.register(adapter, chunker)
 
-        due_source = {
-            "source_id": "source-1",
-            "adapter_id": "test-adapter",
-            "origin_ref": "/path/to/source",
-            "poll_interval_sec": 60,
-            "last_fetched_at": None,
-        }
+        # A failing adapter never gets a _last_polled mark, so it stays due every tick.
+        with patch.object(pipeline, "ingest", side_effect=Exception("Test error")):
+            with patch("context_library.scheduler.poller.logger") as mock_logger:
+                # First tick: failure 1 (INFO level)
+                poller._tick()
+                mock_logger.info.assert_called_once()
+                mock_logger.warning.assert_not_called()
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[due_source]
-        ):
-            with patch.object(pipeline, "ingest", side_effect=Exception("Test error")):
-                with patch("context_library.scheduler.poller.logger") as mock_logger:
-                    # First tick: failure 1 (INFO level)
-                    poller._tick()
-                    mock_logger.info.assert_called_once()
-                    mock_logger.warning.assert_not_called()
+                # Second tick: failure 2 (INFO level)
+                mock_logger.reset_mock()
+                poller._tick()
+                mock_logger.info.assert_called_once()
+                mock_logger.warning.assert_not_called()
 
-                    # Second tick: failure 2 (INFO level)
-                    mock_logger.reset_mock()
-                    poller._tick()
-                    mock_logger.info.assert_called_once()
-                    mock_logger.warning.assert_not_called()
-
-                    # Third tick: failure 3 (WARNING level)
-                    mock_logger.reset_mock()
-                    poller._tick()
-                    mock_logger.warning.assert_called_once()
-                    call_args = str(mock_logger.warning.call_args)
-                    assert "source-1" in call_args
-                    assert "WARNING level" in call_args
+                # Third tick: failure 3 (WARNING level)
+                mock_logger.reset_mock()
+                poller._tick()
+                mock_logger.warning.assert_called_once()
+                call_args = str(mock_logger.warning.call_args)
+                assert "test-adapter" in call_args
+                assert "WARNING level" in call_args
 
     def test_tick_logs_failure_at_error_level_after_6_failures(
         self, pipeline, document_store
     ):
-        """_tick() should log at ERROR level after 6 consecutive failures."""
+        """_tick() should log at ERROR level after 6 consecutive adapter failures."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
         poller = Poller(pipeline, document_store)
         poller.register(adapter, chunker)
 
-        due_source = {
-            "source_id": "source-1",
-            "adapter_id": "test-adapter",
-            "origin_ref": "/path/to/source",
-            "poll_interval_sec": 60,
-            "last_fetched_at": None,
-        }
+        with patch.object(pipeline, "ingest", side_effect=Exception("Test error")):
+            with patch("context_library.scheduler.poller.logger") as mock_logger:
+                # Simulate 6 failures (ticks 1-6)
+                for tick_num in range(6):
+                    mock_logger.reset_mock()
+                    poller._tick()
+
+                    if tick_num < 2:
+                        # Failures 1-2: INFO level
+                        mock_logger.info.assert_called_once()
+                        mock_logger.error.assert_not_called()
+                    elif tick_num < 5:
+                        # Failures 3-5: WARNING level
+                        mock_logger.warning.assert_called_once()
+                        mock_logger.error.assert_not_called()
+                    else:
+                        # Failure 6+: ERROR level
+                        mock_logger.error.assert_called_once()
+                        call_args = str(mock_logger.error.call_args)
+                        assert "test-adapter" in call_args
+                        assert "ERROR level" in call_args
+
+    def test_tick_clears_error_tracker_on_success(self, pipeline, document_store):
+        """A success resets the consecutive-failure count for the adapter."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
+        poller = Poller(pipeline, document_store)
+        poller.register(adapter, chunker)
 
         with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[due_source]
+            pipeline,
+            "ingest",
+            side_effect=[Exception("boom"), Exception("boom"), _pipeline_result()],
         ):
-            with patch.object(pipeline, "ingest", side_effect=Exception("Test error")):
-                with patch("context_library.scheduler.poller.logger") as mock_logger:
-                    # Simulate 6 failures (ticks 1-6)
-                    for tick_num in range(6):
-                        mock_logger.reset_mock()
-                        poller._tick()
+            poller._tick()
+            poller._tick()
+            assert poller._error_tracker["test-adapter"].consecutive_failures == 2
 
-                        if tick_num < 2:
-                            # Failures 1-2: INFO level
-                            mock_logger.info.assert_called_once()
-                            mock_logger.error.assert_not_called()
-                        elif tick_num < 5:
-                            # Failures 3-5: WARNING level
-                            mock_logger.warning.assert_called_once()
-                            mock_logger.error.assert_not_called()
-                        else:
-                            # Failure 6+: ERROR level
-                            mock_logger.error.assert_called_once()
-                            call_args = str(mock_logger.error.call_args)
-                            assert "source-1" in call_args
-                            assert "ERROR level" in call_args
+            poller._tick()
+            assert poller._error_tracker["test-adapter"].consecutive_failures == 0
+
+    def test_tick_detects_programming_errors(self, pipeline, document_store):
+        """_tick() should log programming errors at ERROR level immediately."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
+        # Simulate a programming error (TypeError)
+        def ingest_with_type_error(*args, **kwargs):
+            raise TypeError("Wrong argument type")
+
+        with patch.object(pipeline, "ingest", side_effect=ingest_with_type_error):
+            poller = Poller(pipeline, document_store, tick_interval=0.1)
+            poller.register(adapter, chunker)
+
+            with patch("context_library.scheduler.poller.logger") as mock_logger:
+                poller._tick()
+
+                # Should log at ERROR level immediately (not INFO)
+                # and not record multiple failures for escalation
+                error_calls = [
+                    call for call in mock_logger.error.call_args_list
+                    if "programming error" in str(call).lower()
+                ]
+                assert len(error_calls) > 0, "Programming error was not logged at ERROR level"
 
 
 class TestPollerBackgroundThread:
@@ -527,15 +651,12 @@ class TestPollerBackgroundThread:
 
         poller._tick = counting_tick
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            poller.start()
+        poller.start()
 
-            # Let it run for ~0.3 seconds (should have at least 2 ticks)
-            time.sleep(0.3)
+        # Let it run for ~0.3 seconds (should have at least 2 ticks)
+        time.sleep(0.3)
 
-            poller.stop()
+        poller.stop()
 
         # Should have ticked at least twice
         assert tick_count["count"] >= 2
@@ -544,20 +665,17 @@ class TestPollerBackgroundThread:
         """Setting _stop_event should halt the thread within tick_interval."""
         poller = Poller(pipeline, document_store, tick_interval=1.0)
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            poller.start()
-            thread = poller._thread
+        poller.start()
+        thread = poller._thread
 
-            # Stop should complete quickly (within a couple seconds)
-            start_time = time.time()
-            poller.stop()
-            elapsed = time.time() - start_time
+        # Stop should complete quickly (within a couple seconds)
+        start_time = time.time()
+        poller.stop()
+        elapsed = time.time() - start_time
 
-            # Thread should have joined quickly (much less than tick_interval)
-            assert elapsed < 3.0
-            assert not thread.is_alive()
+        # Thread should have joined quickly (much less than tick_interval)
+        assert elapsed < 3.0
+        assert not thread.is_alive()
 
     def test_stop_timeout_on_hung_thread(self, pipeline, document_store):
         """stop() should timeout if thread is hung on network call and log error."""
@@ -579,30 +697,27 @@ class TestPollerBackgroundThread:
 
         poller._run = hanging_run
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            poller.start()
-            thread = poller._thread
+        poller.start()
+        thread = poller._thread
 
-            # Wait for thread to be hanging
-            hung_event.wait(timeout=2.0)
+        # Wait for thread to be hanging
+        hung_event.wait(timeout=2.0)
 
-            # Call stop - should timeout since thread is hung
-            with patch("context_library.scheduler.poller.logger") as mock_logger:
-                poller.stop()
+        # Call stop - should timeout since thread is hung
+        with patch("context_library.scheduler.poller.logger") as mock_logger:
+            poller.stop()
 
-                # Should have logged an error about timeout
-                mock_logger.error.assert_called_once()
-                error_call = str(mock_logger.error.call_args)
-                assert "timeout" in error_call.lower() or "did not exit" in error_call
+            # Should have logged an error about timeout
+            mock_logger.error.assert_called_once()
+            error_call = str(mock_logger.error.call_args)
+            assert "timeout" in error_call.lower() or "did not exit" in error_call
 
-            # _thread should NOT be cleared because thread didn't exit
-            assert poller._thread is not None
+        # _thread should NOT be cleared because thread didn't exit
+        assert poller._thread is not None
 
-            # Clean up: resume the hung thread
-            resume_event.set()
-            thread.join(timeout=1.0)
+        # Clean up: resume the hung thread
+        resume_event.set()
+        thread.join(timeout=1.0)
 
 
 class TestPollerIntegration:
@@ -617,43 +732,90 @@ class TestPollerIntegration:
     def test_full_lifecycle_with_mocked_pipeline(self, document_store, embedder, differ):
         """Test full start/register/stop lifecycle with mocked pipeline."""
         pipeline = Mock(spec=IngestionPipeline)
+        pipeline.ingest.return_value = _pipeline_result()
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
         poller = Poller(pipeline, document_store, tick_interval=0.1)
         poller.register(adapter, chunker)
 
-        # Mock document_store to return a due source on first call
-        call_count = {"count": 0}
-
-        def counting_get_due():
-            call_count["count"] += 1
-            if call_count["count"] == 1:
-                return [
-                    {
-                        "source_id": "source-1",
-                        "adapter_id": "test-adapter",
-                        "origin_ref": "/path/to/source",
-                        "poll_interval_sec": 60,
-                        "last_fetched_at": None,
-                    }
-                ]
-            return []
-
-        document_store.get_sources_due_for_poll = counting_get_due
-
         poller.start()
-        time.sleep(0.2)
+        assert _wait_for(lambda: pipeline.ingest.called), "Pipeline was never invoked"
         poller.stop()
 
-        # Pipeline.ingest should have been called at least once
+        # Pipeline.ingest should have been called for the registered adapter,
+        # draining from the adapter's own cursor (source_ref="")
         assert pipeline.ingest.called
+        first_call = pipeline.ingest.call_args_list[0]
+        assert first_call.args[0] is adapter
+        assert first_call.args[1] is chunker
+        assert first_call.kwargs == {"source_ref": ""}
+
+
+class TestIngestSlot:
+    """Tests for the public try_begin_ingest()/end_ingest() slot API."""
+
+    def test_try_begin_ingest_claims_slot(self, pipeline, document_store):
+        """First claim succeeds, second is rejected until the slot is released."""
+        poller = Poller(pipeline, document_store)
+
+        assert poller.try_begin_ingest("adapter-x") is True
+        assert poller.try_begin_ingest("adapter-x") is False
+
+        poller.end_ingest("adapter-x")
+        assert poller.try_begin_ingest("adapter-x") is True
+        poller.end_ingest("adapter-x")
+
+    def test_slots_are_per_adapter(self, pipeline, document_store):
+        """A busy slot for one adapter does not block another adapter."""
+        poller = Poller(pipeline, document_store)
+
+        assert poller.try_begin_ingest("adapter-a") is True
+        assert poller.try_begin_ingest("adapter-b") is True
+        poller.end_ingest("adapter-a")
+        poller.end_ingest("adapter-b")
+
+    def test_try_begin_ingest_is_atomic_under_contention(self, pipeline, document_store):
+        """Exactly one of many racing claimants wins the slot."""
+        poller = Poller(pipeline, document_store)
+
+        wins = []
+        barrier = threading.Barrier(8)
+
+        def claim():
+            barrier.wait()
+            if poller.try_begin_ingest("adapter-x"):
+                wins.append(threading.current_thread().name)
+
+        threads = [threading.Thread(target=claim) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(wins) == 1
+        poller.end_ingest("adapter-x")
 
 
 class TestTriggerImmediateIngest:
     """Tests for trigger_immediate_ingest() method."""
 
-    def test_trigger_returns_false_if_poller_stopped(self, pipeline, document_store):
+    def _started_poller(
+        self, pipeline, document_store, adapter, chunker, tick_interval=60.0
+    ) -> Poller:
+        """Build, register, and start a poller whose first tick won't ingest.
+
+        Pre-marks the adapter as freshly polled so the immediate first tick
+        skips it (trigger_immediate_ingest bypasses the interval gate), keeping
+        pipeline call counts deterministic in these tests.
+        """
+        poller = Poller(pipeline, document_store, tick_interval=tick_interval)
+        poller.register(adapter, chunker)
+        poller._last_polled[adapter.adapter_id] = time.monotonic()
+        poller.start()
+        return poller
+
+    def test_trigger_raises_if_poller_stopped(self, pipeline, document_store):
         """trigger_immediate_ingest() should raise PollerNotRunningError if poller is stopped."""
         from context_library.scheduler.exceptions import PollerNotRunningError
 
@@ -667,172 +829,130 @@ class TestTriggerImmediateIngest:
         with pytest.raises(PollerNotRunningError):
             poller.trigger_immediate_ingest("test-adapter")
 
-    def test_trigger_returns_false_if_adapter_not_registered(self, pipeline, document_store):
+    def test_trigger_raises_if_adapter_not_registered(self, pipeline, document_store):
         """trigger_immediate_ingest() should raise AdapterNotRegisteredError for unknown adapter."""
         from context_library.scheduler.exceptions import AdapterNotRegisteredError
 
         poller = Poller(pipeline, document_store, tick_interval=0.5)
+        poller.start()
 
-        with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            poller.start()
+        try:
+            with pytest.raises(AdapterNotRegisteredError):
+                poller.trigger_immediate_ingest("unknown-adapter")
+        finally:
+            poller.stop()
 
-            try:
-                with pytest.raises(AdapterNotRegisteredError):
-                    poller.trigger_immediate_ingest("unknown-adapter")
-            finally:
-                poller.stop()
+    def test_trigger_works_with_zero_sources(self, pipeline, document_store):
+        """An adapter with no source rows can be triggered (the bootstrap case).
 
-    def test_trigger_returns_false_if_no_sources(self, pipeline, document_store):
-        """trigger_immediate_ingest() should raise NoSourcesError if adapter has no sources."""
-        from context_library.scheduler.exceptions import NoSourcesError
-
+        NoSourcesError is gone from this path: the adapter drains from its own
+        cursor, so a freshly registered adapter with zero sources must still run.
+        """
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
         with patch.object(
-            document_store, "get_sources_due_for_poll", return_value=[]
-        ):
-            with patch.object(
-                document_store, "get_sources_for_adapter", return_value=[]
-            ):
-                poller.start()
-
-                try:
-                    with pytest.raises(NoSourcesError):
-                        poller.trigger_immediate_ingest("test-adapter")
-                finally:
-                    poller.stop()
-
-    def test_trigger_calls_ingest_for_all_sources(self, pipeline, document_store):
-        """trigger_immediate_ingest() should call ingest for all sources of the adapter."""
-        adapter = MockAdapter("test-adapter", Domain.NOTES)
-        chunker = MockDomain()
-
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        # Mock sources for the adapter
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path/1"},
-            {"source_id": "source-2", "adapter_id": "test-adapter", "origin_ref": "/path/2"},
-            {"source_id": "source-3", "adapter_id": "test-adapter", "origin_ref": "/path/3"},
-        ]
-
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest"),
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
-            poller.start()
-
+            pipeline, "ingest", return_value=_pipeline_result(processed=0)
+        ) as mock_ingest:
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 result = poller.trigger_immediate_ingest("test-adapter")
                 assert result is True
 
-                # Wait for background thread to process
-                time.sleep(0.2)
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
+                ), "Background ingest did not complete"
 
-                # Should have called ingest 3 times (once per source)
-                assert pipeline.ingest.call_count == 3
+                mock_ingest.assert_called_once_with(adapter, chunker, source_ref="")
             finally:
                 poller.stop()
 
-    def test_trigger_passes_correct_source_ref(self, pipeline, document_store):
-        """trigger_immediate_ingest() should pass origin_ref as source_ref to ingest."""
+    def test_trigger_runs_single_adapter_ingest_with_empty_source_ref(
+        self, pipeline, document_store
+    ):
+        """trigger runs exactly ONE pipeline.ingest for the adapter, source_ref=""."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/specific/path"},
-        ]
-
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest") as mock_ingest,
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
-            poller.start()
-
+        with patch.object(
+            pipeline, "ingest", return_value=_pipeline_result(processed=3)
+        ) as mock_ingest:
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
-                poller.trigger_immediate_ingest("test-adapter")
-                time.sleep(0.2)
+                result = poller.trigger_immediate_ingest("test-adapter")
+                assert result is True
 
-                # Verify ingest was called with correct source_ref
-                mock_ingest.assert_called_once_with(
-                    adapter, chunker, source_ref="/specific/path"
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
                 )
+
+                # One ingest per trigger — no per-source loop, no origin_refs
+                mock_ingest.assert_called_once_with(adapter, chunker, source_ref="")
             finally:
                 poller.stop()
 
-    def test_trigger_updates_last_fetched_at_on_success(self, pipeline, document_store):
-        """trigger_immediate_ingest() should update last_fetched_at after successful ingest."""
-        adapter = MockAdapter("test-adapter", Domain.NOTES)
+    def test_trigger_acks_after_successful_ingest(self, pipeline, document_store):
+        """adapter.ack() is called after the pipeline commits a triggered ingest."""
+        adapter = _AckableAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path"},
-        ]
-
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest"),
-            patch.object(document_store, "update_last_fetched_at") as mock_update,
-        ):
-            poller.start()
-
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 poller.trigger_immediate_ingest("test-adapter")
-                time.sleep(0.2)
-
-                # Should have called update_last_fetched_at for the source
-                mock_update.assert_called_once_with("source-1")
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
+                )
+                assert adapter.ack_calls == 1
             finally:
                 poller.stop()
 
-    def test_trigger_handles_ingest_failure_gracefully(self, pipeline, document_store):
-        """trigger_immediate_ingest() should continue on ingest failure (per-source isolation)."""
+    def test_trigger_does_not_ack_on_failure(self, pipeline, document_store):
+        """adapter.ack() is NOT called when the triggered ingest fails."""
+        adapter = _AckableAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
+        with patch.object(pipeline, "ingest", side_effect=RuntimeError("ingest blew up")):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
+            try:
+                poller.trigger_immediate_ingest("test-adapter")
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
+                )
+                assert adapter.ack_calls == 0
+            finally:
+                poller.stop()
+
+    def test_trigger_sets_last_polled_on_success(self, pipeline, document_store):
+        """A successful triggered ingest advances the adapter's last-polled mark."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path/1"},
-            {"source_id": "source-2", "adapter_id": "test-adapter", "origin_ref": "/path/2"},
-        ]
-
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            # Make first ingest fail, second succeed
-            patch.object(pipeline, "ingest", side_effect=[Exception("Test error"), None]),
-            patch.object(document_store, "update_last_fetched_at") as mock_update,
-        ):
-            poller.start()
-
+        with patch.object(pipeline, "ingest", return_value=_pipeline_result()):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
+            mark_before = poller._last_polled["test-adapter"]
             try:
                 poller.trigger_immediate_ingest("test-adapter")
-                time.sleep(0.2)
+                assert _wait_for(
+                    lambda: poller._last_polled["test-adapter"] > mark_before
+                ), "last-polled mark was not advanced"
+            finally:
+                poller.stop()
 
-                # Both sources should have been attempted
-                assert pipeline.ingest.call_count == 2
-                # Only second source should have been updated
-                mock_update.assert_called_once_with("source-2")
+    def test_trigger_does_not_set_last_polled_on_failure(self, pipeline, document_store):
+        """A failed triggered ingest leaves the last-polled mark unchanged."""
+        adapter = MockAdapter("test-adapter", Domain.NOTES)
+        chunker = MockDomain()
+
+        with patch.object(pipeline, "ingest", side_effect=RuntimeError("boom")):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
+            mark_before = poller._last_polled["test-adapter"]
+            try:
+                poller.trigger_immediate_ingest("test-adapter")
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
+                )
+                assert poller._last_polled["test-adapter"] == mark_before
             finally:
                 poller.stop()
 
@@ -841,25 +961,12 @@ class TestTriggerImmediateIngest:
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        # Create a source that would take time to process
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path"},
-        ]
-
         def slow_ingest(*args, **kwargs):
             time.sleep(0.5)  # Simulate slow ingest
+            return _pipeline_result()
 
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest", side_effect=slow_ingest),
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
-            poller.start()
-
+        with patch.object(pipeline, "ingest", side_effect=slow_ingest):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 # trigger_immediate_ingest should return quickly
                 start_time = time.time()
@@ -872,56 +979,40 @@ class TestTriggerImmediateIngest:
             finally:
                 poller.stop()
 
-    def test_trigger_returns_false_when_ingest_already_in_progress(self, pipeline, document_store):
-        """trigger_immediate_ingest() should raise IngestAlreadyInProgressError if ingest already in progress."""
+    def test_trigger_raises_when_ingest_already_in_progress(self, pipeline, document_store):
+        """trigger_immediate_ingest() should raise IngestAlreadyInProgressError if busy."""
         from context_library.scheduler.exceptions import IngestAlreadyInProgressError
 
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        # Create sources with slow ingest to allow us to call trigger before completion
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path"},
-        ]
+        ingest_started = threading.Event()
 
         def slow_ingest(*args, **kwargs):
+            ingest_started.set()
             time.sleep(0.5)  # Slow enough to trigger second call before completion
+            return _pipeline_result()
 
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest", side_effect=slow_ingest),
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
-            poller.start()
-
+        with patch.object(pipeline, "ingest", side_effect=slow_ingest):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 # First call should succeed
                 result1 = poller.trigger_immediate_ingest("test-adapter")
                 assert result1 is True
+                assert ingest_started.wait(timeout=2.0)
 
-                # Second call while first is still in progress should raise IngestAlreadyInProgressError
+                # Second call while first is still in progress should raise
                 with pytest.raises(IngestAlreadyInProgressError):
                     poller.trigger_immediate_ingest("test-adapter")
             finally:
                 poller.stop()
 
     def test_trigger_race_condition_protection_with_lock(self, pipeline, document_store):
-        """trigger_immediate_ingest() check-and-set should be atomic (protected by lock)."""
+        """trigger_immediate_ingest() check-and-set should be atomic (try_begin_ingest)."""
         from context_library.scheduler.exceptions import IngestAlreadyInProgressError
 
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
-
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path"},
-        ]
 
         call_count = {"count": 0}
         condition = threading.Condition()
@@ -932,15 +1023,10 @@ class TestTriggerImmediateIngest:
                 call_count["count"] += 1
                 condition.notify()
             time.sleep(0.5)
+            return _pipeline_result()
 
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest", side_effect=slow_ingest),
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
-            poller.start()
-
+        with patch.object(pipeline, "ingest", side_effect=slow_ingest):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 # First call should succeed
                 result1 = poller.trigger_immediate_ingest("test-adapter")
@@ -950,14 +1036,16 @@ class TestTriggerImmediateIngest:
                 with condition:
                     condition.wait_for(lambda: call_count["count"] > 0, timeout=1.0)
 
-                # Second call should raise IngestAlreadyInProgressError (not spawn another thread)
+                # Second call should raise (not spawn another thread)
                 with pytest.raises(IngestAlreadyInProgressError):
                     poller.trigger_immediate_ingest("test-adapter")
 
-                # Wait for background threads to finish
-                time.sleep(0.6)
+                # Wait for background thread to finish
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
+                )
 
-                # Only one ingest should have been called (not two)
+                # Only one ingest should have been run (not two)
                 assert call_count["count"] == 1
             finally:
                 poller.stop()
@@ -967,13 +1055,6 @@ class TestTriggerImmediateIngest:
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path"},
-        ]
-
         ingest_started = threading.Event()
         ingest_finished = threading.Event()
 
@@ -981,14 +1062,10 @@ class TestTriggerImmediateIngest:
             ingest_started.set()
             time.sleep(0.3)  # Simulate work
             ingest_finished.set()
+            return _pipeline_result()
 
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest", side_effect=slow_ingest),
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
-            poller.start()
+        with patch.object(pipeline, "ingest", side_effect=slow_ingest):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 # Trigger background ingest
                 result = poller.trigger_immediate_ingest("test-adapter")
@@ -1007,82 +1084,56 @@ class TestTriggerImmediateIngest:
                 if poller._thread and poller._thread.is_alive():
                     poller.stop()
 
-    def test_tick_skips_sources_when_background_ingest_in_progress(self, pipeline, document_store):
-        """_tick() should skip sources when a background ingest is in progress for that adapter."""
+    def test_tick_skips_adapter_when_background_ingest_in_progress(
+        self, pipeline, document_store
+    ):
+        """_tick() must not ingest an adapter whose background ingest is running."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
-
-        poller = Poller(pipeline, document_store, tick_interval=0.1)
-        poller.register(adapter, chunker)
-
-        # Set up a due source
-        due_source = {
-            "source_id": "source-1",
-            "adapter_id": "test-adapter",
-            "origin_ref": "/path/to/source",
-            "poll_interval_sec": 60,
-            "last_fetched_at": None,
-        }
 
         ingest_started = threading.Event()
 
         def slow_ingest(*args, **kwargs):
             ingest_started.set()
-            time.sleep(0.5)  # Hold ingest lock for a while
+            time.sleep(0.5)  # Hold the ingest slot for a while
+            return _pipeline_result()
 
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[due_source]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=[due_source]),
-            patch.object(pipeline, "ingest", side_effect=slow_ingest),
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
-            poller.start()
+        with patch.object(pipeline, "ingest", side_effect=slow_ingest) as mock_ingest:
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 # Trigger background ingest
                 result = poller.trigger_immediate_ingest("test-adapter")
                 assert result is True
 
-                # Wait for background ingest to start
+                # Wait for background ingest to start (slot held)
                 assert ingest_started.wait(timeout=2.0), "Background ingest did not start"
 
-                # Now tick while ingest is in progress
-                # The tick should skip this source since _ingest_in_progress is set
-                initial_ingest_calls = pipeline.ingest.call_count
+                # Make the adapter due, then tick while the slot is busy —
+                # the tick must skip it because the ingest slot is claimed.
+                poller._last_polled.pop("test-adapter", None)
+                initial_ingest_calls = mock_ingest.call_count
 
                 poller._tick()
 
-                # Should not have called ingest again (would be initial_ingest_calls + 1)
-                # since the background ingest is in progress
-                assert pipeline.ingest.call_count == initial_ingest_calls
+                assert mock_ingest.call_count == initial_ingest_calls
             finally:
                 if poller._thread and poller._thread.is_alive():
                     poller.stop()
 
     def test_stop_clears_stale_ingest_in_progress_flags(self, pipeline, document_store):
-        """stop() should clear stale _ingest_in_progress flags after shutdown."""
+        """The per-adapter in-progress flag is set during ingest and cleared after stop()."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
-
-        poller = Poller(pipeline, document_store, tick_interval=0.5)
-        poller.register(adapter, chunker)
-
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path"},
-        ]
 
         ingest_started = threading.Event()
 
         def slow_ingest(*args, **kwargs):
             ingest_started.set()
             time.sleep(0.3)
+            return _pipeline_result()
 
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[]),
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest", side_effect=slow_ingest),
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
-            poller.start()
+        with patch.object(pipeline, "ingest", side_effect=slow_ingest):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 # Trigger background ingest
                 result = poller.trigger_immediate_ingest("test-adapter")
@@ -1114,30 +1165,21 @@ class TestTriggerImmediateIngest:
         assert result is None
 
     def test_get_ingest_result_tracks_success(self, pipeline, document_store):
-        """get_ingest_result() should track successful ingest for all sources."""
+        """get_ingest_result() reflects the pipeline result dict on success."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path1"},
-            {"source_id": "source-2", "adapter_id": "test-adapter", "origin_ref": "/path2"},
-        ]
-
-        with (
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest"),
-            patch.object(document_store, "update_last_fetched_at"),
+        with patch.object(
+            pipeline, "ingest", return_value=_pipeline_result(processed=2, failed=0)
         ):
-            poller = Poller(pipeline, document_store, tick_interval=0.1)
-            poller.register(adapter, chunker)
-            poller.start()
-
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 result = poller.trigger_immediate_ingest("test-adapter")
                 assert result is True
 
-                # Wait for background thread to complete
-                time.sleep(0.5)
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
+                )
 
                 ingest_result = poller.get_ingest_result("test-adapter")
                 assert ingest_result is not None
@@ -1148,39 +1190,24 @@ class TestTriggerImmediateIngest:
                 assert ingest_result.overall_success is True
                 assert ingest_result.completed_at is not None
             finally:
-                if poller._thread and poller._thread.is_alive():
-                    poller.stop()
+                poller.stop()
 
-    def test_get_ingest_result_tracks_failures(self, pipeline, document_store):
-        """get_ingest_result() should track per-source failures."""
+    def test_get_ingest_result_tracks_partial_failures(self, pipeline, document_store):
+        """get_ingest_result() reflects per-source failures reported by the pipeline."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        sources = [
-            {"source_id": "source-1", "adapter_id": "test-adapter", "origin_ref": "/path1"},
-            {"source_id": "source-2", "adapter_id": "test-adapter", "origin_ref": "/path2"},
-        ]
-
-        def ingest_side_effect(*args, **kwargs):
-            # Fail on the second source
-            if kwargs.get("source_ref") == "/path2":
-                raise RuntimeError("Test error")
-
-        with (
-            patch.object(document_store, "get_sources_for_adapter", return_value=sources),
-            patch.object(pipeline, "ingest", side_effect=ingest_side_effect),
-            patch.object(document_store, "update_last_fetched_at"),
+        with patch.object(
+            pipeline, "ingest", return_value=_pipeline_result(processed=1, failed=1)
         ):
-            poller = Poller(pipeline, document_store, tick_interval=0.1)
-            poller.register(adapter, chunker)
-            poller.start()
-
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
             try:
                 result = poller.trigger_immediate_ingest("test-adapter")
                 assert result is True
 
-                # Wait for background thread to complete
-                time.sleep(0.5)
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
+                )
 
                 ingest_result = poller.get_ingest_result("test-adapter")
                 assert ingest_result is not None
@@ -1190,43 +1217,29 @@ class TestTriggerImmediateIngest:
                 assert ingest_result.overall_success is False
                 assert ingest_result.partial_success is True
             finally:
-                if poller._thread and poller._thread.is_alive():
-                    poller.stop()
+                poller.stop()
 
-    def test_tick_detects_programming_errors(self, pipeline, document_store):
-        """_tick() should log programming errors at ERROR level immediately."""
+    def test_get_ingest_result_tracks_whole_fetch_exception(self, pipeline, document_store):
+        """An exception from pipeline.ingest is recorded as a failed result."""
         adapter = MockAdapter("test-adapter", Domain.NOTES)
         chunker = MockDomain()
 
-        source = {
-            "source_id": "source-1",
-            "adapter_id": "test-adapter",
-            "origin_ref": "/path",
-            "poll_interval_sec": 60,
-            "last_fetched_at": None,
-        }
+        with patch.object(pipeline, "ingest", side_effect=TypeError("bad call")):
+            poller = self._started_poller(pipeline, document_store, adapter, chunker)
+            try:
+                poller.trigger_immediate_ingest("test-adapter")
+                assert _wait_for(
+                    lambda: poller.get_ingest_result("test-adapter") is not None
+                )
 
-        # Simulate a programming error (TypeError)
-        def ingest_with_type_error(*args, **kwargs):
-            raise TypeError("Wrong argument type")
-
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[source]),
-            patch.object(pipeline, "ingest", side_effect=ingest_with_type_error),
-        ):
-            poller = Poller(pipeline, document_store, tick_interval=0.1)
-            poller.register(adapter, chunker)
-
-            with patch("context_library.scheduler.poller.logger") as mock_logger:
-                poller._tick()
-
-                # Should log at ERROR level immediately (not INFO)
-                # and not record multiple failures for escalation
-                error_calls = [
-                    call for call in mock_logger.error.call_args_list
-                    if "programming error" in str(call).lower()
-                ]
-                assert len(error_calls) > 0, "Programming error was not logged at ERROR level"
+                ingest_result = poller.get_ingest_result("test-adapter")
+                assert ingest_result is not None
+                assert ingest_result.sources_failed >= 1
+                assert ingest_result.overall_success is False
+                # TypeError is a programming error and is flagged as such
+                assert ingest_result.had_programming_errors is True
+            finally:
+                poller.stop()
 
 
 class _AckableAdapter(MockAdapter):
@@ -1249,16 +1262,7 @@ class TestPollerCommitAck:
     def test_tick_acks_after_successful_ingest(self, pipeline, document_store):
         adapter = _AckableAdapter("filesystem_helper:default", Domain.DOCUMENTS)
         chunker = MockDomain()
-        source = {
-            "source_id": "src-1",
-            "adapter_id": "filesystem_helper:default",
-            "origin_ref": "/some/file.md",
-        }
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[source]),
-            patch.object(pipeline, "ingest", return_value={}),
-            patch.object(document_store, "update_last_fetched_at"),
-        ):
+        with patch.object(pipeline, "ingest", return_value={}):
             poller = Poller(pipeline, document_store, tick_interval=0.1)
             poller.register(adapter, chunker)
             poller._tick()
@@ -1268,15 +1272,7 @@ class TestPollerCommitAck:
     def test_tick_does_not_ack_after_failed_ingest(self, pipeline, document_store):
         adapter = _AckableAdapter("filesystem_helper:default", Domain.DOCUMENTS)
         chunker = MockDomain()
-        source = {
-            "source_id": "src-1",
-            "adapter_id": "filesystem_helper:default",
-            "origin_ref": "/some/file.md",
-        }
-        with (
-            patch.object(document_store, "get_sources_due_for_poll", return_value=[source]),
-            patch.object(pipeline, "ingest", side_effect=RuntimeError("ingest blew up")),
-        ):
+        with patch.object(pipeline, "ingest", side_effect=RuntimeError("ingest blew up")):
             poller = Poller(pipeline, document_store, tick_interval=0.1)
             poller.register(adapter, chunker)
             poller._tick()

--- a/tests/server/test_adapters.py
+++ b/tests/server/test_adapters.py
@@ -461,10 +461,13 @@ class TestResetAdapter:
         assert data["reingestion_triggered"] is False
         assert any("Adapter is not registered" in err for err in data["errors"])
 
-    def test_returns_207_when_no_sources_found(self, client: TestClient) -> None:
-        """Test that NoSourcesError returns 207 with warning message."""
-        from context_library.scheduler.exceptions import NoSourcesError
+    def test_zero_source_adapter_reingestion_succeeds(self, client: TestClient) -> None:
+        """An adapter with zero source rows still triggers re-ingestion (bootstrap case).
 
+        trigger_immediate_ingest no longer raises NoSourcesError: adapters drain
+        from their own persisted cursor, so a freshly reset adapter with no
+        source rows must still be re-ingested. The reset should return 200.
+        """
         # Create a mock adapter that succeeds
         mock_adapter = MagicMock()
         mock_adapter.adapter_id = "test-adapter"
@@ -472,21 +475,18 @@ class TestResetAdapter:
 
         client.app.state.helper_adapters = [mock_adapter]
 
-        # Mock poller to raise NoSourcesError
+        # Poller trigger succeeds even though the adapter has no source rows
         poller = MagicMock()
-        poller.trigger_immediate_ingest.side_effect = NoSourcesError("No sources found")
+        poller.trigger_immediate_ingest.return_value = True
         client.app.state.poller = poller
 
         resp = client.post("/adapters/test-adapter/reset")
-        # Endpoint returns 207 Partial Success if library reset succeeded but re-ingestion failed
-        assert resp.status_code == 207
+        assert resp.status_code == 200
         data = resp.json()
         assert data["adapter_id"] == "test-adapter"
-        assert data["helper_reset"]["ok"] is True
-        assert data["library_reset"]["sources_reset"] is not None
-        assert isinstance(data["library_reset"]["sources_reset"], int)
-        assert data["reingestion_triggered"] is False
-        assert any("No sources found" in err for err in data["errors"])
+        assert data["reingestion_triggered"] is True
+        assert data["errors"] == []
+        poller.trigger_immediate_ingest.assert_called_once_with("test-adapter")
 
     def test_returns_207_when_ingest_already_in_progress(self, client: TestClient) -> None:
         """Test that IngestAlreadyInProgressError returns 207 with warning message."""


### PR DESCRIPTION
## Root cause (found via live audit 2026-07-13)

The poller scheduled per-source: `get_sources_due_for_poll()` requires `poll_strategy='pull' AND poll_interval_sec IS NOT NULL` — but nothing ever wrote `poll_interval_sec` (`pipeline.register_source()` omits it, and git history shows it was never passed). All ~35k source rows have it NULL, so **zero sources were ever due**: filesystem/obsidian/oura/apple_music_library froze in production on 2026-06-13..20, the day manual deploy-session triggers stopped. June's apparent health was `trigger_immediate_ingest()` from resets, not the scheduler.

## Fix

**Per-adapter scheduling** — the correct unit for helper adapters, which drain all sources in one `fetch()` from their own persisted cursor:
- Due when `poll_interval_sec` (adapter attribute, defaulting to the tick interval, i.e. `helper_pull_poll_interval_sec`=300s) has elapsed since the adapter's last successful run; failures retry next tick with per-adapter INFO→WARN→ERROR escalation; adapters with zero source rows bootstrap correctly.
- **Shared per-adapter ingest slot** (`try_begin_ingest`/`end_ingest`): now actually held during the tick's ingest and shared with `trigger_immediate_ingest` and the push route's targeted `?adapter_id=` path — closing the three-way cursor/ack races (route reports `status=skipped` when busy).
- `trigger_immediate_ingest`: single per-adapter ingest (`source_ref=""`), **acks after commit** (previously never acked — helper cursors stayed staged), no more `NoSourcesError`.

**FilesystemHelperAdapter** hardening this depends on:
- `fetch()` always uses the persisted cursor; `source_ref` is ignored (the old non-empty-override would have sent file paths / since-timestamps as change-sequence cursors the moment the poller passed one — the code contradicted its own comment).
- Truncated NDJSON stream (no meta line) now **raises** instead of returning normally, so a partially received page is never acked.

## Tests

`test_poller.py` rewritten to the new contract (59 tests), `test_adapters.py` bootstrap case, `test_filesystem_helper.py` +3 for cursor-authority/truncation. 83 passed (scheduler+adapters), 122 passed (filesystem suites), 24 passed (ingest route). Ruff clean. Pre-existing unrelated failures (youtube/calendar/location/permission) untouched.

## Deploy note

After merge: restart the container, then reset filesystem/obsidian/oura/music cursors (library adapter reset + helper `POST /collectors/{name}/reset`) to drain the month-old backlog. Pairs with context-helpers PR #8 (stops the mac's 3.4s push loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)