### PR TITLE
feat(ingest): endpoint-keyed commit-acks + dead-letter table

### DIFF
--- a/src/context_library/adapters/apple_health.py
+++ b/src/context_library/adapters/apple_health.py
@@ -229,6 +229,32 @@ class AppleHealthAdapter(HelperAckMixin, BaseAdapter):
         self._api_key = api_key
         self._device_id = device_id
         self._helper_collector_name = "health"
+        # Endpoints whose fetch failed in the most recent fetch() run; read by
+        # _ack_keys() so ack() commits only the successful endpoints' cursors.
+        self._failed_endpoints: list[str] = []
+
+    # All helper cursor keys, matching HealthCollector.push_cursor_keys() on
+    # the mac. "/health/heart-rate" maps to "health_heart_rate".
+    _ALL_ACK_KEYS = [
+        "health_workouts", "health_activity", "health_sleep",
+        "health_heart_rate", "health_spo2", "health_mindfulness",
+    ]
+
+    @staticmethod
+    def _endpoint_to_key(endpoint: str) -> str:
+        return "health_" + endpoint.rsplit("/", 1)[-1].replace("-", "_")
+
+    def _ack_keys(self) -> list[str] | None:
+        """Commit only the endpoints that fetched successfully.
+
+        The helper's ack is collector-global; after a PartialFetchError an
+        unkeyed ack would also commit the failed endpoint's staged cursor,
+        permanently skipping the page it never delivered.
+        """
+        if not self._failed_endpoints:
+            return None  # everything succeeded — commit all staged keys
+        failed = {self._endpoint_to_key(e) for e in self._failed_endpoints}
+        return [k for k in self._ALL_ACK_KEYS if k not in failed]
 
     @property
     def adapter_id(self) -> str:
@@ -262,6 +288,9 @@ class AppleHealthAdapter(HelperAckMixin, BaseAdapter):
         ]
 
         failed_endpoints = []
+        # Reset per-fetch failure tracking; _ack_keys() reads this after ingest
+        # so ack() commits only the successful endpoints' helper cursors.
+        self._failed_endpoints = []
 
         for endpoint, handler, item_label in endpoints_config:
             try:
@@ -279,6 +308,7 @@ class AppleHealthAdapter(HelperAckMixin, BaseAdapter):
         except EndpointFetchError:
             failed_endpoints.append("/health/heart-rate")
 
+        self._failed_endpoints = list(failed_endpoints)
         total_endpoints = len(endpoints_config) + 1  # +1 for heart_rate
         if failed_endpoints:
             if len(failed_endpoints) == total_endpoints:

--- a/src/context_library/adapters/apple_reminders.py
+++ b/src/context_library/adapters/apple_reminders.py
@@ -56,7 +56,7 @@ This adapter:
 import logging
 from typing import Iterator
 
-from context_library.adapters.base import BaseAdapter
+from context_library.adapters.base import BaseAdapter, HelperAckMixin
 from context_library.storage.models import (
     Domain,
     PollStrategy,
@@ -78,7 +78,7 @@ except ImportError:
     pass
 
 
-class AppleRemindersAdapter(BaseAdapter):
+class AppleRemindersAdapter(HelperAckMixin, BaseAdapter):
     """Adapter that ingests reminders from a macOS Apple Reminders helper service.
 
     This adapter communicates with an HTTP service on the Mac that reads from
@@ -122,9 +122,14 @@ class AppleRemindersAdapter(BaseAdapter):
         self._list_name = list_name
         self._account_id = account_id
         self._client = httpx.Client(timeout=30.0)
-        # NOTE: reminders is served by a *paged* helper collector (consume_stash),
-        # which advances its page cursor on serve and does not honour commit-ack
-        # mode — so this adapter deliberately does NOT mix in HelperAckMixin.
+        # Reminders is served by a *paged* helper collector (consume_stash).
+        # Helpers now stage the page cursor under ?ack=true and commit it on
+        # POST /collectors/reminders/ack, so this adapter opts into commit-ack:
+        # a page whose ingest fails downstream is re-served instead of lost
+        # (delivery used to be at-most-once — the cursor advanced on serve).
+        # Older helpers ignore both the param and the ack (commit-on-serve),
+        # so mixed versions behave exactly as before.
+        self._helper_collector_name = "reminders"
 
     @property
     def adapter_id(self) -> str:
@@ -237,6 +242,9 @@ class AppleRemindersAdapter(BaseAdapter):
             params["list"] = self._list_name
         if since:
             params["since"] = since
+        # Commit-ack: the helper stages its page cursor instead of committing
+        # on serve; the ingest caller invokes ack() after the durable commit.
+        params.update(self._ack_params())
 
         # Build headers
         headers = {"Authorization": f"Bearer {self._api_key}"}

--- a/src/context_library/adapters/base.py
+++ b/src/context_library/adapters/base.py
@@ -212,14 +212,41 @@ class HelperAckMixin:
         """Query params that put the helper endpoint in commit-ack (stage) mode."""
         return {"ack": "true"}
 
+    def _ack_keys(self) -> "list[str] | None":
+        """Helper cursor keys to commit, or None to commit everything staged.
+
+        Multi-endpoint adapters (oura, apple_health) override this to return
+        only the keys of endpoints that fetched successfully: the helper's ack
+        endpoint is collector-global, so an unkeyed ack after a partial fetch
+        would commit the FAILED endpoint's staged cursor too, permanently
+        skipping its page. Returning [] suppresses the ack entirely (nothing
+        safe to commit).
+        """
+        return None
+
     def ack(self) -> None:
         import httpx
 
+        keys = self._ack_keys()
+        if keys is not None and not keys:
+            logger.warning(
+                "%s: skipping commit-ack — no endpoint fetched successfully",
+                type(self).__name__,
+            )
+            return
+
         try:
+            # Helpers that predate keyed acks ignore the JSON body and commit
+            # all staged keys — the pre-change behaviour — so mixed versions
+            # degrade gracefully rather than breaking.
+            kwargs: dict = {}
+            if keys is not None:
+                kwargs["json"] = {"keys": keys}
             resp = httpx.post(
                 f"{self._api_url}/collectors/{self._helper_collector_name}/ack",  # type: ignore[attr-defined]
                 headers={"Authorization": f"Bearer {self._api_key}"},  # type: ignore[attr-defined]
                 timeout=30.0,
+                **kwargs,
             )
             resp.raise_for_status()
         except Exception as e:  # noqa: BLE001 - ack is best-effort

--- a/src/context_library/adapters/oura.py
+++ b/src/context_library/adapters/oura.py
@@ -261,6 +261,32 @@ class OuraAdapter(HelperAckMixin, BaseAdapter):
         self._api_key = api_key
         self._device_id = device_id
         self._helper_collector_name = "oura"  # commit-ack via HelperAckMixin
+        # Endpoints whose fetch failed in the most recent fetch() run; read by
+        # _ack_keys() so ack() commits only the successful endpoints' cursors.
+        self._failed_endpoints: list[str] = []
+
+    # All helper cursor keys, matching OuraCollector.push_cursor_keys() on the
+    # mac. An endpoint path "/oura/heart_rate" maps to the key "oura_heart_rate".
+    _ALL_ACK_KEYS = [
+        "oura_sleep", "oura_readiness", "oura_activity", "oura_workouts",
+        "oura_heart_rate", "oura_spo2", "oura_tags", "oura_sessions",
+    ]
+
+    @staticmethod
+    def _endpoint_to_key(endpoint: str) -> str:
+        return "oura_" + endpoint.rsplit("/", 1)[-1].replace("-", "_")
+
+    def _ack_keys(self) -> list[str] | None:
+        """Commit only the endpoints that fetched successfully.
+
+        The helper's ack is collector-global; after a PartialFetchError an
+        unkeyed ack would also commit the failed endpoint's staged cursor,
+        permanently skipping the page it never delivered.
+        """
+        if not self._failed_endpoints:
+            return None  # everything succeeded — commit all staged keys
+        failed = {self._endpoint_to_key(e) for e in self._failed_endpoints}
+        return [k for k in self._ALL_ACK_KEYS if k not in failed]
 
     @property
     def adapter_id(self) -> str:
@@ -311,6 +337,9 @@ class OuraAdapter(HelperAckMixin, BaseAdapter):
             ("/oura/sessions", self._process_session, "mindfulness session"),
         ]
         failed_endpoints = []
+        # Reset per-fetch failure tracking; _ack_keys() reads this after ingest
+        # so ack() commits only the successful endpoints' helper cursors.
+        self._failed_endpoints = []
 
         for endpoint, handler, item_label in endpoints_config:
             try:
@@ -331,6 +360,7 @@ class OuraAdapter(HelperAckMixin, BaseAdapter):
             failed_endpoints.append("/oura/heart_rate")
 
         # Surface endpoint failures to the caller
+        self._failed_endpoints = list(failed_endpoints)
         total_endpoints = len(endpoints_config) + 1  # +1 for heart_rate
         if failed_endpoints:
             if len(failed_endpoints) == total_endpoints:

--- a/src/context_library/core/pipeline.py
+++ b/src/context_library/core/pipeline.py
@@ -127,6 +127,22 @@ class IngestionPipeline:
         self._active_runs: dict[str, _PipelineRun] = {}
         self._runs_lock = threading.Lock()
 
+    def _record_dead_letter(
+        self, adapter_id: str, source_id: str, error_type: str, message: str
+    ) -> None:
+        """Durably record a skipped source (best-effort; never raises).
+
+        Per-source failures don't stop the page from committing and being
+        acked, so the helper's cursor advances past them — this row is the only
+        recoverable trace of the dropped item.
+        """
+        try:
+            self.document_store.record_dead_letter(adapter_id, source_id, error_type, message)
+        except Exception:
+            logger.exception(
+                "Failed to record dead letter for %s/%s (non-fatal)", adapter_id, source_id
+            )
+
     def _get_source_lock(self, source_id: str) -> threading.Lock:
         """Return the per-source lock for source_id, creating it if needed.
 
@@ -230,6 +246,7 @@ class IngestionPipeline:
         chunks_unchanged_total = 0
         errors: list[dict] = []
         store_consistency: dict[str, str] = {}
+        succeeded_ids: list[str] = []
 
         # Register active run for observability via GET /admin/pipelines
         _run = _PipelineRun(
@@ -323,6 +340,7 @@ class IngestionPipeline:
                                         _metric_attrs = {"adapter_id": adapter.adapter_id, "domain": effective_domain.value}
                                         _ingest_sources_counter.add(1, _metric_attrs)
                                         _ingest_duration_histogram.record(time.monotonic() - _source_start, _metric_attrs)
+                                        succeeded_ids.append(content.source_id)
                                         continue
 
                                     # Case 2: Content changed - process added/removed/unchanged chunks
@@ -564,6 +582,7 @@ class IngestionPipeline:
                                     _ingest_chunks_added_counter.add(len(added_chunks), _metric_attrs)
                                     _ingest_chunks_retired_counter.add(len(diff_result.removed_hashes), _metric_attrs)
                                     _ingest_duration_histogram.record(time.monotonic() - _source_start, _metric_attrs)
+                                    succeeded_ids.append(content.source_id)
 
                             except ChunkingError as e:
                                 # Handle chunking errors (domain-specific parser/processing failures)
@@ -579,6 +598,9 @@ class IngestionPipeline:
                                     "message": str(e),
                                     "source_id_attr": e.source_id,
                                 })
+                                self._record_dead_letter(
+                                    adapter.adapter_id, content.source_id, "ChunkingError", str(e)
+                                )
                                 store_consistency[content.source_id] = "error"
                                 continue
                             except EmbeddingError as e:
@@ -596,6 +618,9 @@ class IngestionPipeline:
                                     "chunk_hash": e.chunk_hash,
                                     "chunk_index": e.chunk_index,
                                 })
+                                self._record_dead_letter(
+                                    adapter.adapter_id, content.source_id, "EmbeddingError", str(e)
+                                )
                                 store_consistency[content.source_id] = "error"
                                 continue
                             except StorageError as e:
@@ -615,6 +640,9 @@ class IngestionPipeline:
                                     "store_type": e.store_type,
                                     "inconsistent": e.inconsistent,
                                 })
+                                self._record_dead_letter(
+                                    adapter.adapter_id, content.source_id, "StorageError", str(e)
+                                )
                                 continue
                             except Exception as e:
                                 # Handle any other unexpected errors
@@ -629,6 +657,9 @@ class IngestionPipeline:
                                     "error_type": type(e).__name__,
                                     "message": str(e),
                                 })
+                                self._record_dead_letter(
+                                    adapter.adapter_id, content.source_id, type(e).__name__, str(e)
+                                )
                                 store_consistency[content.source_id] = "error"
                                 continue
                 except PartialFetchError as e:
@@ -699,6 +730,18 @@ class IngestionPipeline:
                     ingest_span.set_status(StatusCode.ERROR)
                     ingest_span.record_exception(error)
                     raise error
+
+            # Self-heal dead letters: sources that previously failed and have now
+            # ingested cleanly no longer need their dead-letter rows. The COUNT
+            # guard keeps the common case (no dead letters) to a single query.
+            try:
+                if succeeded_ids and self.document_store.count_dead_letters(adapter.adapter_id) > 0:
+                    for _sid in succeeded_ids:
+                        self.document_store.clear_dead_letters(
+                            adapter_id=adapter.adapter_id, source_id=_sid
+                        )
+            except Exception:
+                logger.exception("Dead-letter cleanup failed (non-fatal)")
 
             return {
                 "sources_processed": sources_processed,

--- a/src/context_library/server/app.py
+++ b/src/context_library/server/app.py
@@ -16,7 +16,7 @@ from context_library.core.embedder import Embedder
 from context_library.core.pipeline import IngestionPipeline
 from context_library.scheduler.poller import Poller
 from context_library.server.config import ServerConfig
-from context_library.server.routes import admin, adapters, chunks, health, ingest, retrieve, sources, stats
+from context_library.server.routes import admin, adapters, chunks, dead_letters, health, ingest, retrieve, sources, stats
 from context_library.storage.chromadb_store import ChromaDBVectorStore
 from context_library.storage.document_store import DocumentStore
 from context_library.telemetry import setup_telemetry, shutdown_telemetry
@@ -279,6 +279,7 @@ def create_app() -> FastAPI:
     app.include_router(chunks.router)
     app.include_router(stats.router)
     app.include_router(admin.router)
+    app.include_router(dead_letters.router)
 
 
     # Mount static SPA if built assets exist

--- a/src/context_library/server/routes/dead_letters.py
+++ b/src/context_library/server/routes/dead_letters.py
@@ -1,0 +1,69 @@
+"""Dead-letter inspection endpoints.
+
+Per-source ingest failures are skipped so the rest of their page can commit,
+and the page is then acked — the helper's cursor advances past the failed
+items. The dead_letters table is the durable record of those drops; these
+endpoints expose it for monitoring and post-fix cleanup.
+"""
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, Query, Request
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["dead-letters"])
+
+
+class DeadLetter(BaseModel):
+    id: int
+    adapter_id: str
+    source_id: str
+    error_type: str
+    message: str
+    first_seen: str
+    last_seen: str
+    retry_count: int
+
+
+class DeadLetterListResponse(BaseModel):
+    total: int
+    dead_letters: list[DeadLetter]
+
+
+class DeadLetterClearResponse(BaseModel):
+    deleted: int
+
+
+@router.get("/dead-letters", response_model=DeadLetterListResponse)
+async def list_dead_letters(
+    request: Request,
+    adapter_id: str | None = Query(default=None, description="Filter by adapter_id"),
+    limit: int = Query(default=100, ge=1, le=1000),
+) -> DeadLetterListResponse:
+    """List sources that failed ingest and were skipped by a committed page."""
+    ds = request.app.state.document_store
+    rows = await asyncio.to_thread(ds.list_dead_letters, adapter_id, limit)
+    total = await asyncio.to_thread(ds.count_dead_letters, adapter_id)
+    return DeadLetterListResponse(
+        total=total,
+        dead_letters=[DeadLetter(**row) for row in rows],
+    )
+
+
+@router.post("/dead-letters/clear", response_model=DeadLetterClearResponse)
+async def clear_dead_letters(
+    request: Request,
+    adapter_id: str | None = Query(default=None, description="Only clear rows for this adapter"),
+    source_id: str | None = Query(default=None, description="Only clear rows for this source"),
+) -> DeadLetterClearResponse:
+    """Delete dead-letter rows after manual review or a successful re-ingest."""
+    ds = request.app.state.document_store
+    deleted = await asyncio.to_thread(ds.clear_dead_letters, adapter_id, source_id)
+    logger.info(
+        "Cleared %d dead-letter row(s) (adapter_id=%s, source_id=%s)",
+        deleted, adapter_id, source_id,
+    )
+    return DeadLetterClearResponse(deleted=deleted)

--- a/src/context_library/storage/document_store.py
+++ b/src/context_library/storage/document_store.py
@@ -2176,6 +2176,86 @@ class DocumentStore:
                     f"Source '{source_id}' does not exist"
                 )
 
+    # ------------------------------------------------------------------
+    # Dead letters — per-source ingest failures skipped by a committed page
+    # ------------------------------------------------------------------
+
+    def record_dead_letter(
+        self, adapter_id: str, source_id: str, error_type: str, message: str
+    ) -> None:
+        """Upsert a dead-letter row for a source that failed ingest.
+
+        The surrounding page commits and is acked (the cursor advances past the
+        failed item), so this row is the only durable record that the item was
+        dropped. Keyed by (adapter_id, source_id, error_type); repeats bump
+        retry_count and last_seen.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        with self._write_lock, self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO dead_letters
+                    (adapter_id, source_id, error_type, message, first_seen, last_seen)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (adapter_id, source_id, error_type) DO UPDATE SET
+                    message = excluded.message,
+                    last_seen = excluded.last_seen,
+                    retry_count = retry_count + 1
+                """,
+                (adapter_id, source_id, error_type, message[:2000], now, now),
+            )
+
+    def list_dead_letters(
+        self, adapter_id: str | None = None, limit: int = 100
+    ) -> list[dict]:
+        """List dead-letter rows, newest failures first."""
+        sql = (
+            "SELECT id, adapter_id, source_id, error_type, message,"
+            " first_seen, last_seen, retry_count FROM dead_letters"
+        )
+        params: list = []
+        if adapter_id:
+            sql += " WHERE adapter_id = ?"
+            params.append(adapter_id)
+        sql += " ORDER BY last_seen DESC LIMIT ?"
+        params.append(limit)
+        cursor = self.conn.cursor()
+        return [dict(row) for row in cursor.execute(sql, params).fetchall()]
+
+    def count_dead_letters(self, adapter_id: str | None = None) -> int:
+        """Count dead-letter rows, optionally for one adapter."""
+        cursor = self.conn.cursor()
+        if adapter_id:
+            row = cursor.execute(
+                "SELECT COUNT(*) FROM dead_letters WHERE adapter_id = ?", (adapter_id,)
+            ).fetchone()
+        else:
+            row = cursor.execute("SELECT COUNT(*) FROM dead_letters").fetchone()
+        return int(row[0])
+
+    def clear_dead_letters(
+        self, adapter_id: str | None = None, source_id: str | None = None
+    ) -> int:
+        """Delete dead-letter rows (after a successful re-ingest or manual review).
+
+        Returns the number of rows deleted.
+        """
+        sql = "DELETE FROM dead_letters"
+        clauses = []
+        params: list = []
+        if adapter_id:
+            clauses.append("adapter_id = ?")
+            params.append(adapter_id)
+        if source_id:
+            clauses.append("source_id = ?")
+            params.append(source_id)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        with self._write_lock, self.conn:
+            cursor = self.conn.cursor()
+            cursor.execute(sql, params)
+            return cursor.rowcount
+
     def get_sources_due_for_poll(self) -> list[dict]:
         """Get all sources due for polling.
 

--- a/src/context_library/storage/schema.sql
+++ b/src/context_library/storage/schema.sql
@@ -119,3 +119,22 @@ CREATE TABLE IF NOT EXISTS lancedb_sync_log (
 );
 
 CREATE INDEX IF NOT EXISTS idx_lancedb_sync_log_synced_at ON lancedb_sync_log(synced_at);
+
+-- Dead letters: per-source ingest failures that were skipped so the rest of
+-- the page could commit. The page is acked (cursor advances), so without this
+-- record the failed item would be silently unrecoverable. Rows are upserted by
+-- (adapter_id, source_id, error_type) with a retry counter; retry tooling can
+-- reset the adapter cursor or re-fetch individual sources and clear rows.
+CREATE TABLE IF NOT EXISTS dead_letters (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    adapter_id   TEXT NOT NULL,
+    source_id    TEXT NOT NULL,
+    error_type   TEXT NOT NULL,
+    message      TEXT NOT NULL,
+    first_seen   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    retry_count  INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (adapter_id, source_id, error_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dead_letters_adapter ON dead_letters(adapter_id);

--- a/tests/adapters/test_ack_keys.py
+++ b/tests/adapters/test_ack_keys.py
@@ -1,0 +1,98 @@
+"""Tests for endpoint-keyed commit-acks (HelperAckMixin._ack_keys).
+
+The helper's POST /collectors/{name}/ack is collector-global; multi-endpoint
+adapters must ack only the cursor keys of endpoints that fetched successfully,
+otherwise a partial fetch commits the failed endpoint's staged cursor and its
+page is permanently skipped.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from context_library.adapters.apple_health import AppleHealthAdapter
+from context_library.adapters.oura import OuraAdapter
+
+
+def _oura():
+    return OuraAdapter(api_url="http://helper:1", api_key="k")
+
+
+def _health():
+    return AppleHealthAdapter(api_url="http://helper:1", api_key="k")
+
+
+class TestOuraAckKeys:
+    def test_all_success_acks_everything(self):
+        a = _oura()
+        a._failed_endpoints = []
+        assert a._ack_keys() is None  # None = commit all staged keys
+
+    def test_partial_failure_excludes_failed_keys(self):
+        a = _oura()
+        a._failed_endpoints = ["/oura/heart_rate", "/oura/sleep"]
+        keys = a._ack_keys()
+        assert "oura_heart_rate" not in keys
+        assert "oura_sleep" not in keys
+        assert "oura_readiness" in keys
+        assert len(keys) == 6
+
+    def test_all_failed_returns_empty(self):
+        a = _oura()
+        a._failed_endpoints = [
+            "/oura/sleep", "/oura/readiness", "/oura/activity", "/oura/workouts",
+            "/oura/spo2", "/oura/tags", "/oura/sessions", "/oura/heart_rate",
+        ]
+        assert a._ack_keys() == []
+
+
+class TestHealthAckKeys:
+    def test_hyphenated_endpoint_maps_to_underscore_key(self):
+        a = _health()
+        a._failed_endpoints = ["/health/heart-rate"]
+        keys = a._ack_keys()
+        assert "health_heart_rate" not in keys
+        assert "health_workouts" in keys
+        assert len(keys) == 5
+
+    def test_keys_match_helper_cursor_keys(self):
+        # Must mirror HealthCollector.push_cursor_keys() on the mac
+        assert AppleHealthAdapter._ALL_ACK_KEYS == [
+            "health_workouts", "health_activity", "health_sleep",
+            "health_heart_rate", "health_spo2", "health_mindfulness",
+        ]
+
+
+class TestAckPost:
+    def test_ack_sends_keys_body_on_partial(self):
+        a = _oura()
+        a._failed_endpoints = ["/oura/sleep"]
+        with patch("httpx.post", return_value=MagicMock(raise_for_status=lambda: None)) as post:
+            a.ack()
+        assert post.called
+        body = post.call_args.kwargs["json"]
+        assert "oura_sleep" not in body["keys"]
+        assert "oura_heart_rate" in body["keys"]
+
+    def test_ack_sends_no_body_on_full_success(self):
+        a = _oura()
+        a._failed_endpoints = []
+        with patch("httpx.post", return_value=MagicMock(raise_for_status=lambda: None)) as post:
+            a.ack()
+        assert post.called
+        assert "json" not in post.call_args.kwargs
+
+    def test_ack_skipped_when_all_endpoints_failed(self):
+        a = _oura()
+        a._failed_endpoints = list(a._ALL_ACK_KEYS)  # any 8 entries mapping to all keys
+        a._failed_endpoints = [
+            "/oura/sleep", "/oura/readiness", "/oura/activity", "/oura/workouts",
+            "/oura/spo2", "/oura/tags", "/oura/sessions", "/oura/heart_rate",
+        ]
+        with patch("httpx.post") as post:
+            a.ack()
+        post.assert_not_called()
+
+    def test_ack_never_raises(self):
+        a = _oura()
+        a._failed_endpoints = []
+        with patch("httpx.post", side_effect=ConnectionError("down")):
+            a.ack()  # must not raise

--- a/tests/server/test_dead_letters.py
+++ b/tests/server/test_dead_letters.py
@@ -1,0 +1,31 @@
+"""Tests for the dead-letter inspection routes."""
+
+
+class TestDeadLetterRoutes:
+    def test_list_empty(self, client):
+        resp = client.get("/dead-letters")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 0
+        assert body["dead_letters"] == []
+
+    def test_list_and_filter(self, client, ds):
+        ds.record_dead_letter("oura:default", "oura/sleep/1", "ChunkingError", "boom")
+        ds.record_dead_letter("apple_health:default", "apple_health/spo2/1", "StorageError", "x")
+
+        resp = client.get("/dead-letters")
+        assert resp.json()["total"] == 2
+
+        resp = client.get("/dead-letters", params={"adapter_id": "oura:default"})
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["dead_letters"][0]["source_id"] == "oura/sleep/1"
+
+    def test_clear(self, client, ds):
+        ds.record_dead_letter("oura:default", "s1", "E", "m")
+        ds.record_dead_letter("oura:default", "s2", "E", "m")
+
+        resp = client.post("/dead-letters/clear", params={"adapter_id": "oura:default", "source_id": "s1"})
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 1
+        assert client.get("/dead-letters").json()["total"] == 1

--- a/tests/storage/test_dead_letters.py
+++ b/tests/storage/test_dead_letters.py
@@ -1,0 +1,87 @@
+"""Tests for the dead-letter store: durable record of skipped ingest failures."""
+
+import os
+import tempfile
+
+import pytest
+
+from context_library.storage.document_store import DocumentStore
+
+
+@pytest.fixture
+def store():
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    temp_path = temp_file.name
+    temp_file.close()
+    ds = DocumentStore(temp_path)
+    yield ds
+    ds.close()
+    try:
+        os.unlink(temp_path)
+    except OSError:
+        pass
+
+
+class TestRecordDeadLetter:
+    def test_record_and_list(self, store):
+        store.record_dead_letter("oura:default", "oura/sleep/2026-01-01", "ChunkingError", "boom")
+        rows = store.list_dead_letters()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["adapter_id"] == "oura:default"
+        assert row["source_id"] == "oura/sleep/2026-01-01"
+        assert row["error_type"] == "ChunkingError"
+        assert row["message"] == "boom"
+        assert row["retry_count"] == 0
+
+    def test_repeat_failure_upserts_and_bumps_retry_count(self, store):
+        store.record_dead_letter("a:1", "s1", "StorageError", "first")
+        store.record_dead_letter("a:1", "s1", "StorageError", "second")
+        rows = store.list_dead_letters()
+        assert len(rows) == 1
+        assert rows[0]["message"] == "second"
+        assert rows[0]["retry_count"] == 1
+
+    def test_distinct_error_types_are_separate_rows(self, store):
+        store.record_dead_letter("a:1", "s1", "ChunkingError", "x")
+        store.record_dead_letter("a:1", "s1", "EmbeddingError", "y")
+        assert store.count_dead_letters() == 2
+
+    def test_message_truncated(self, store):
+        store.record_dead_letter("a:1", "s1", "E", "x" * 5000)
+        assert len(store.list_dead_letters()[0]["message"]) == 2000
+
+
+class TestListAndCount:
+    def test_filter_by_adapter(self, store):
+        store.record_dead_letter("a:1", "s1", "E", "m")
+        store.record_dead_letter("b:1", "s2", "E", "m")
+        assert store.count_dead_letters("a:1") == 1
+        assert [r["adapter_id"] for r in store.list_dead_letters("a:1")] == ["a:1"]
+
+    def test_limit(self, store):
+        for i in range(5):
+            store.record_dead_letter("a:1", f"s{i}", "E", "m")
+        assert len(store.list_dead_letters(limit=3)) == 3
+        assert store.count_dead_letters() == 5
+
+
+class TestClear:
+    def test_clear_by_source(self, store):
+        store.record_dead_letter("a:1", "s1", "E", "m")
+        store.record_dead_letter("a:1", "s2", "E", "m")
+        deleted = store.clear_dead_letters(adapter_id="a:1", source_id="s1")
+        assert deleted == 1
+        assert store.count_dead_letters() == 1
+
+    def test_clear_by_adapter(self, store):
+        store.record_dead_letter("a:1", "s1", "E", "m")
+        store.record_dead_letter("b:1", "s2", "E", "m")
+        assert store.clear_dead_letters(adapter_id="a:1") == 1
+        assert store.count_dead_letters() == 1
+
+    def test_clear_all(self, store):
+        store.record_dead_letter("a:1", "s1", "E", "m")
+        store.record_dead_letter("b:1", "s2", "E", "m")
+        assert store.clear_dead_letters() == 2
+        assert store.count_dead_letters() == 0


### PR DESCRIPTION
Stacked on #568. Closes the ack-granularity gap identified in the 2026-07-13 sync audit:

- **Endpoint-keyed acks**: `pipeline.ingest()` only raises when ALL sources fail, so a partial oura/health fetch was acked as a success and the helper committed every staged cursor — including the failed endpoint's, permanently skipping its page (audit finding P3). `HelperAckMixin.ack()` now sends `{"keys": [...]}`; oura/apple_health track per-fetch endpoint failures and ack only the successful endpoints' cursor keys; an all-failed fetch suppresses the ack. Helpers that predate keyed acks ignore the body — no deploy-order coupling. Helper-side keyed commit lands in context-helpers (companion PR).
- **Dead letters** (findings P1/P2): per-source failures skipped inside a committed page are now durably recorded in a `dead_letters` table (upsert by adapter/source/error with retry_count), self-healing on later clean ingest, with `GET /dead-letters` / `POST /dead-letters/clear`. Previously the only trace was a transient `errors[]` list and a log line.

Tests: 18 new (store + ack-keys) + 3 route tests; 326 passed across core/adapters/server suites. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)