### PR TITLE
fix(pipeline): resurrect reset sources; clear drain cursor on reset

### DIFF
--- a/src/context_library/adapters/filesystem_helper.py
+++ b/src/context_library/adapters/filesystem_helper.py
@@ -328,6 +328,18 @@ class FilesystemHelperAdapter(RemoteAdapter):
                 )
                 return
 
+    def reset(self):
+        """Reset helper-side state AND the in-memory drain cursor.
+
+        The inherited reset only clears the helper's persisted state; leaving
+        self._cursor populated made the next drain resume from a cursor issued
+        against the pre-reset index — served empty pages in production when the
+        rebuilt index had a similar seq range.
+        """
+        result = super().reset()
+        self._cursor = ""
+        return result
+
     # ack() is inherited from RemoteAdapter: it POSTs
     # {service_url}/collectors/filesystem/ack (best-effort) after the pipeline
     # commits, committing the cursor the helper staged during the ?ack=true pull.

--- a/src/context_library/core/pipeline.py
+++ b/src/context_library/core/pipeline.py
@@ -328,7 +328,15 @@ class IngestionPipeline:
 
                                     # Case 1: Content unchanged - just update last_fetched_at, skip writes.
                                     # Still update display_name so existing sources are backfilled.
-                                    if not diff_result.changed:
+                                    # EXCEPTION: if the source's chunks were retired (adapter
+                                    # reset), "unchanged" must NOT short-circuit — skipping here
+                                    # left reset sources retired forever, because the differ
+                                    # compares against version history that survives the reset.
+                                    # Fall through to Case 2 so the chunks are rewritten.
+                                    retired_needs_rewrite = bool(chunks) and not (
+                                        self.document_store.has_active_chunks(content.source_id)
+                                    )
+                                    if not diff_result.changed and not retired_needs_rewrite:
                                         self.document_store.update_last_fetched_at(content.source_id)
                                         if display_name:
                                             self.document_store.update_display_name(content.source_id, display_name)
@@ -377,12 +385,19 @@ class IngestionPipeline:
                                         create_version_span.set_attribute("version", new_version)
 
                                     # Separate added and unchanged chunks
-                                    added_chunks = [
-                                        c for c in chunks if c.chunk_hash in diff_result.added_hashes
-                                    ]
-                                    unchanged_chunks = [
-                                        c for c in chunks if c.chunk_hash in diff_result.unchanged_hashes
-                                    ]
+                                    if retired_needs_rewrite and not diff_result.changed:
+                                        # Resurrection after an adapter reset: the "unchanged"
+                                        # chunks' vectors were deleted at retirement, so every
+                                        # chunk must be re-embedded and re-added as if new.
+                                        added_chunks = list(chunks)
+                                        unchanged_chunks = []
+                                    else:
+                                        added_chunks = [
+                                            c for c in chunks if c.chunk_hash in diff_result.added_hashes
+                                        ]
+                                        unchanged_chunks = [
+                                            c for c in chunks if c.chunk_hash in diff_result.unchanged_hashes
+                                        ]
 
                                     # Embed added chunks with context headers for semantic enrichment
                                     # Context header is prepended only for embedding, not stored in content field

--- a/src/context_library/storage/document_store.py
+++ b/src/context_library/storage/document_store.py
@@ -2256,6 +2256,21 @@ class DocumentStore:
             cursor.execute(sql, params)
             return cursor.rowcount
 
+    def has_active_chunks(self, source_id: str) -> bool:
+        """True if the source has at least one non-retired chunk.
+
+        Used by the pipeline's unchanged short-circuit: an "unchanged" source
+        whose chunks were all retired (adapter reset) must be rewritten, not
+        skipped — the diff compares against version history, which survives
+        resets.
+        """
+        cursor = self.conn.cursor()
+        row = cursor.execute(
+            "SELECT 1 FROM chunks WHERE source_id = ? AND retired_at IS NULL LIMIT 1",
+            (source_id,),
+        ).fetchone()
+        return row is not None
+
     def get_sources_due_for_poll(self) -> list[dict]:
         """Get all sources due for polling.
 

--- a/tests/core/test_pipeline_resurrection.py
+++ b/tests/core/test_pipeline_resurrection.py
@@ -1,0 +1,111 @@
+"""Regression: adapter reset + unchanged content must resurrect, not skip.
+
+Production failure: reset_adapter() retires all chunks but preserves version
+history; on re-ingest the differ saw identical hashes → the unchanged
+short-circuit skipped the source → its chunks stayed retired forever."""
+
+import os
+import tempfile
+
+import pytest
+
+from context_library.core.differ import Differ
+from context_library.core.embedder import Embedder
+from context_library.core.pipeline import IngestionPipeline
+from context_library.domains.notes import NotesDomain
+from context_library.storage.chromadb_store import ChromaDBVectorStore
+from context_library.storage.document_store import DocumentStore
+from context_library.storage.models import (
+    Domain,
+    NormalizedContent,
+    PollStrategy,
+    StructuralHints,
+)
+from context_library.adapters.base import BaseAdapter
+
+
+class _StaticAdapter(BaseAdapter):
+    """Yields one fixed markdown document every fetch."""
+
+    def __init__(self):
+        self.acked = 0
+
+    @property
+    def adapter_id(self):
+        return "static:test"
+
+    @property
+    def domain(self):
+        return Domain.NOTES
+
+    @property
+    def poll_strategy(self):
+        return PollStrategy.PULL
+
+    @property
+    def normalizer_version(self):
+        return "1.0"
+
+    def fetch(self, source_ref: str):
+        yield NormalizedContent(
+            markdown="# Stable\n\nThis content never changes.",
+            source_id="static/doc.md",
+            structural_hints=StructuralHints(
+                has_headings=True, has_lists=False, has_tables=False,
+                natural_boundaries=[], file_path=None,
+            ),
+            normalizer_version="1.0",
+        )
+
+
+@pytest.fixture
+def pipeline_env():
+    dbf = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    dbf.close()
+    ds = DocumentStore(dbf.name)
+    with tempfile.TemporaryDirectory() as vdir:
+        vs = ChromaDBVectorStore(vdir)
+        pipe = IngestionPipeline(
+            document_store=ds,
+            embedder=Embedder(model_name="all-MiniLM-L6-v2"),
+            differ=Differ(),
+            vector_store=vs,
+        )
+        yield pipe, ds, vs
+    ds.close()
+    os.unlink(dbf.name)
+
+
+class TestResetResurrection:
+    def test_unchanged_source_with_retired_chunks_is_rewritten(self, pipeline_env):
+        pipe, ds, vs = pipeline_env
+        adapter = _StaticAdapter()
+        chunker = NotesDomain()
+
+        r1 = pipe.ingest(adapter, chunker, source_ref="")
+        assert r1["sources_processed"] == 1
+        assert ds.has_active_chunks("static/doc.md")
+        vectors_before = vs.count()
+        assert vectors_before > 0
+
+        # Adapter reset: retires all chunks, preserves version history
+        reset = ds.reset_adapter("static:test")
+        assert reset["chunks_retired"] > 0
+        assert not ds.has_active_chunks("static/doc.md")
+
+        # Re-ingest identical content: must resurrect, not skip
+        r2 = pipe.ingest(adapter, chunker, source_ref="")
+        assert r2["sources_failed"] == 0
+        assert ds.has_active_chunks("static/doc.md")
+        assert vs.count() >= vectors_before  # vectors re-added
+
+    def test_unchanged_source_with_active_chunks_still_skips(self, pipeline_env):
+        pipe, ds, _ = pipeline_env
+        adapter = _StaticAdapter()
+        chunker = NotesDomain()
+
+        pipe.ingest(adapter, chunker, source_ref="")
+        v1 = ds.get_latest_version("static/doc.md")
+        r2 = pipe.ingest(adapter, chunker, source_ref="")
+        assert r2["chunks_added"] == 0
+        assert ds.get_latest_version("static/doc.md") == v1  # no new version


### PR DESCRIPTION
Found via live verification of the ~/Documents document-conversion drain, which settled at 10 sources:

1. **Reset resurrection**: `reset_adapter()` retires chunks but preserves version history; the pipeline's unchanged short-circuit then skipped identical re-serves, leaving reset sources retired forever. Case 1 now rewrites when a source has no active chunks — treating all chunks as added, since retirement deleted their vectors too. Regression tests cover resurrect + normal-skip paths.
2. **Drain cursor on reset**: `FilesystemHelperAdapter.reset()` never cleared `self._cursor` (contradicting its own docs); post-reset drains resumed from a stale cursor and served empty pages whenever the rebuilt index had a similar seq range. Companion context-helpers change adds generation-stamped cursors so the helper rejects stale cursors server-side as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)